### PR TITLE
Do not add hash items while iterating over them.

### DIFF
--- a/lib/json-schema/attributes/maximum_inclusive.rb
+++ b/lib/json-schema/attributes/maximum_inclusive.rb
@@ -3,8 +3,7 @@ module JSON
     class MaximumInclusiveAttribute < Attribute
       def self.validate(current_schema, data, fragments, validator, options = {})
         if data.is_a?(Numeric)
-          current_schema.schema['maximumCanEqual'] = true if current_schema.schema['maximumCanEqual'].nil?
-          if (current_schema.schema['maximumCanEqual'] ? data > current_schema.schema['maximum'] : data >= current_schema.schema['maximum'])
+          if (current_schema.schema['maximumCanEqual'] == false ? data >= current_schema.schema['maximum'] : data > current_schema.schema['maximum'])
             message = "The property '#{build_fragment(fragments)}' did not have a maximum value of #{current_schema.schema['maximum']}, "
             message += current_schema.schema['exclusiveMaximum'] ? 'exclusively' : 'inclusively'
             raise ValidationError.new(message, fragments, current_schema)

--- a/lib/json-schema/attributes/minimum_inclusive.rb
+++ b/lib/json-schema/attributes/minimum_inclusive.rb
@@ -3,8 +3,7 @@ module JSON
     class MinimumInclusiveAttribute < Attribute
       def self.validate(current_schema, data, fragments, validator, options = {})
         if data.is_a?(Numeric)
-          current_schema.schema['minimumCanEqual'] = true if current_schema.schema['minimumCanEqual'].nil?
-          if (current_schema.schema['minimumCanEqual'] ? data < current_schema.schema['minimum'] : data <= current_schema.schema['minimum'])
+          if (current_schema.schema['minimumCanEqual'] == false ? data <= current_schema.schema['minimum'] : data < current_schema.schema['minimum'])
             message = "The property '#{build_fragment(fragments)}' did not have a minimum value of #{current_schema.schema['minimum']}, "
             message += current_schema.schema['exclusiveMinimum'] ? 'exclusively' : 'inclusively'
             raise ValidationError.new(message, fragments, current_schema)


### PR DESCRIPTION
There is a Ruby 1.9 issue with adding hash items while iterating referenced here: https://github.com/hoxworth/json-schema/commit/2571c3ff5380a85a08fef49070e7f00a76c7a3e5#diff-0

Fixed by avoiding scheme alteration.
