### PR TITLE
Gem::Specification::find_by_name errors

### DIFF
--- a/lib/json-schema/validator.rb
+++ b/lib/json-schema/validator.rb
@@ -293,6 +293,8 @@ module JSON
 
     if begin
         Gem::Specification::find_by_name('json')
+      rescue Gem::LoadError
+        false
       rescue
         Gem.available?('json')
       end
@@ -304,6 +306,8 @@ module JSON
 
     if begin
         Gem::Specification::find_by_name('yajl-ruby')
+      rescue Gem::LoadError
+        false
       rescue
         Gem.available?('yajl-ruby')
       end
@@ -317,6 +321,8 @@ module JSON
 
     if begin
         Gem::Specification::find_by_name('uuidtools')
+      rescue Gem::LoadError
+        false
       rescue
         Gem.available?('uuidtools')
       end


### PR DESCRIPTION
`Gem::Specification::find_by_name` raises `Gem::LoadError` when it's unable to find required gem. So using this method in boolean statements requires one more rescue statement. You could easily see this issue by running gem tests on rubygems 1.8.5 without one of the optional gems installed: json, yajl-ruby or uuidtools.

Checking gem availibality certainly needs a helper, I'm just not sure where to place it.

The patch in this request fixes the Gem::LoadError exception.
