### PR TITLE
Fix require of attributes and validators to work in Rubinius 

### DIFF
--- a/lib/json-schema.rb
+++ b/lib/json-schema.rb
@@ -3,6 +3,6 @@ $LOAD_PATH.unshift "#{File.dirname(__FILE__)}/json-schema"
 require 'rubygems'
 require 'schema'
 require 'validator'
-Dir[File.join(File.dirname(__FILE__), "json-schema/attributes/*")].each {|file| require file }
-Dir[File.join(File.dirname(__FILE__), "json-schema/validators/*")].each {|file| require file }
+Dir[File.join(File.dirname(__FILE__), "json-schema/attributes/*.rb")].each {|file| require file }
+Dir[File.join(File.dirname(__FILE__), "json-schema/validators/*.rb")].each {|file| require file }
 require 'uri/file'


### PR DESCRIPTION
When loading attributes and validators json-schema loads all files under attributes and validators dirs, including the byte code cache files generated by Rubinius, with this change we only require .rb files.
