### PR TITLE
Json::Schema::*Error classes should inherit from StandardError instead of Exception.

### DIFF
--- a/lib/json-schema/validator.rb
+++ b/lib/json-schema/validator.rb
@@ -8,7 +8,7 @@ require 'date'
 module JSON
 
   class Schema
-    class ValidationError < Exception
+    class ValidationError < StandardError
       attr_reader :fragments, :schema
 
       def initialize(message, fragments, schema)
@@ -19,10 +19,10 @@ module JSON
       end
     end
 
-    class SchemaError < Exception
+    class SchemaError < StandardError
     end
 
-    class JsonParseError < Exception
+    class JsonParseError < StandardError
     end
 
     class Attribute


### PR DESCRIPTION
Application exceptions should subclass StandardError like everybody else's.  Exception is for language-level issues.  Thanks!
