### PR TITLE
Fix deprecation warnings

### DIFF
--- a/lib/json-schema.rb
+++ b/lib/json-schema.rb
@@ -11,7 +11,7 @@ if begin
   
   # Force MultiJson to load an engine before we define the JSON constant here; otherwise,
   # it looks for things that are under the JSON namespace that aren't there (since we have defined it here)
-  MultiJson.engine
+  MultiJson.adapter
 end
 
 $LOAD_PATH.unshift "#{File.dirname(__FILE__)}/json-schema"


### PR DESCRIPTION
MultiJson 1.3.x marks some methods as deprecated, which generates a warning during startup
