### PR TITLE
Consider unrecognized types invalid.

### DIFF
--- a/lib/json-schema/attributes/type.rb
+++ b/lib/json-schema/attributes/type.rb
@@ -39,7 +39,7 @@ module JSON
             when "any"
               valid = true
             else
-              valid = true
+              valid = false
             end
           elsif type.is_a?(Hash) && union
             # Validate as a schema

--- a/test/test_jsonschema_draft3.rb
+++ b/test/test_jsonschema_draft3.rb
@@ -13,6 +13,11 @@ class JSONSchemaDraft3Test < Test::Unit::TestCase
     data = {
       "a" => nil
     }
+
+    # Test fat-fingered types
+    schema["properties"]["a"]["type"] = "intger"
+    data["a"] = 5
+    assert(!JSON::Validator.validate(schema,data))
     
     # Test integers
     schema["properties"]["a"]["type"] = "integer"
@@ -107,7 +112,7 @@ class JSONSchemaDraft3Test < Test::Unit::TestCase
     data['a'] = true
     assert(!JSON::Validator.validate(schema,data))
     
-    assert(JSON::Validator.validate({'type' => 'objec'}, {'a' => true}))
+    assert(JSON::Validator.validate({'type' => 'object'}, {'a' => true}))
     assert(JSON::Validator.validate({'type' => 'object'}, {}))
     assert(!JSON::Validator.validate({'type' => 'object'}, []))
     assert(!JSON::Validator.validate({'type' => 'object'}, 3))


### PR DESCRIPTION
It's very easy to fat-finger a type declaration, and silent failure is evil.
In fact, there was a typo in the tests ("objec" instead of "object").
