### PR TITLE
Fix Issue with MultiJson Feature Detection

### DIFF
--- a/lib/json-schema/validator.rb
+++ b/lib/json-schema/validator.rb
@@ -407,7 +407,7 @@ module JSON
 
       def parse(s)
         if defined?(MultiJson)
-          MultiJson.respond_to?(:load) ? MultiJson.load(s) : MultiJson.decode(s)
+          MultiJson.respond_to?(:adapter) ? MultiJson.load(s) : MultiJson.decode(s)
         else
           case @@json_backend.to_s
           when 'json'


### PR DESCRIPTION
You can't reliably detect whether `MultiJson` responds to `load` since Kernel defines a `load` method, so use `adapter` as a proxy.

This should resolve #39.
