### PR TITLE
Restore 1.8.7 compatibility.

### DIFF
--- a/lib/json-schema/attributes/additionalproperties.rb
+++ b/lib/json-schema/attributes/additionalproperties.rb
@@ -1,4 +1,4 @@
-require_relative 'extends'
+require 'json-schema/attributes/extends'
 
 module JSON
   class Schema

--- a/lib/json-schema/attributes/extends.rb
+++ b/lib/json-schema/attributes/extends.rb
@@ -1,4 +1,4 @@
-require_relative 'ref'
+require 'json-schema/attributes/ref'
 
 module JSON
   class Schema

--- a/test/test_extends_and_additionalProperties.rb
+++ b/test/test_extends_and_additionalProperties.rb
@@ -7,7 +7,7 @@ class ExtendsNestedTest < Test::Unit::TestCase
     file = File.expand_path("../schemas/#{schema_name}.schema.json",__FILE__)
     errors = JSON::Validator.fully_validate file, data
     msg.sub! /\.$/, '' if msg
-    send (valid ? :assert_equal : :refute_equal), [], errors, \
+    send (valid ? :assert_equal : :assert_not_equal), [], errors, \
       "Schema should be #{valid ? :valid : :invalid}#{msg ? ".\n[#{schema_name}] #{msg}" : ''}"
   end
 


### PR DESCRIPTION
The 1.8.7 travis-ci build for our interpol gem just started failing due to the 1.0.9 release not being compatible with 1.8.7:

http://travis-ci.org/#!/seomoz/interpol/jobs/2535030

This restores compatibility with 1.8.7.

It'd be nice to get this project on travis CI with a build matrix covering all the ruby versions you intend to support, to help prevent future releases breaking compatibility.
