### PR TITLE
Add failing test demonstrating failure of complex union type.

### DIFF
--- a/test/test_jsonschema_draft3.rb
+++ b/test/test_jsonschema_draft3.rb
@@ -206,24 +206,25 @@ class JSONSchemaDraft3Test < Test::Unit::TestCase
     assert(!JSON::Validator.validate(schema,data))
 
     # Test an array of unioned-type objects that prevent additionalProperties
-    schema["properties"]["a"]["type"] = {
+    schema["properties"]["a"] = {
       'type' => 'array',
       'items' => {
         'type' => [
-          { 'type' => 'object', 'properties' => { "b" => { "type" => "integer" } }, 'additionalProperties' => false },
-          { 'type' => 'object', 'properties' => { "c" => { "type" => "string" } }, 'additionalProperties' => false }
-        ]
+          { 'type' => 'object', 'properties' => { "b" => { "type" => "integer" } } },
+          { 'type' => 'object', 'properties' => { "c" => { "type" => "string" } } }
+        ],
+        'additionalProperties' => false
       }
     }
 
     data["a"] = [{"b" => 5}, {"c" => "foo"}]
-    assert(JSON::Validator.validate(schema,data))
+    errors = JSON::Validator.fully_validate(schema, data)
+    assert(errors.empty?, errors.join("\n"))
+
     data["a"] << {"c" => false}
     assert(!JSON::Validator.validate(schema,data))
-   end
-  
-  
-  
+  end
+
   def test_required
     # Set up the default datatype
     schema = {


### PR DESCRIPTION
We're doing some stuff with complex union types, and, unfortunately, it's failing validation when I don't think it should be.

I've added a failing test case demonstrating a case where it should pass validation but should not.  (Obviously, this PR should not be merged until somebody changes the implementation to make it pass).

I may get around to fixing this at some point but I don't have time right now, and I figure @hoxworth may be able to fix this much easier.
