### PR TITLE
maxitems error message correction

### DIFF
--- a/lib/json-schema/attributes/maxitems.rb
+++ b/lib/json-schema/attributes/maxitems.rb
@@ -3,7 +3,7 @@ module JSON
     class MaxItemsAttribute < Attribute
       def self.validate(current_schema, data, fragments, processor, validator, options = {})
         if data.is_a?(Array) && (data.compact.size > current_schema.schema['maxItems'])
-          message = "The property '#{build_fragment(fragments)}' did not contain a minimum number of items #{current_schema.schema['minItems']}"
+          message = "The property '#{build_fragment(fragments)}' had more items than the allowed #{current_schema.schema['maxItems']}"
           validation_error(processor, message, fragments, current_schema, self, options[:record_errors])
         end
       end


### PR DESCRIPTION
Correction for the error message generated when an array exceeds the number of elements set in maxItems.
