### PR TITLE
Fix one of logic

### DIFF
--- a/lib/json-schema/attributes/oneof.rb
+++ b/lib/json-schema/attributes/oneof.rb
@@ -7,11 +7,10 @@ module JSON
           schema = JSON::Schema.new(element,current_schema.uri,validator)
 
           begin
-            valid = schema.validate(data,fragments,processor,options)
-            # handle when option[;record_errors] => true
-            validation_errors += 1 unless valid
+            # need to raise exceptions on error because
+            # schema.validate doesn't reliably return true/false
+            schema.validate(data,fragments,processor,options.merge(:record_errors => false))
           rescue ValidationError
-            # handle when option[;record_errors] => false
             validation_errors += 1
           end
 

--- a/test/data/one_of_ref_links_data.json
+++ b/test/data/one_of_ref_links_data.json
@@ -1,0 +1,5 @@
+{ "links":
+  [{ "rel" : ["self"] , "href":"http://api.example.com/api/object/3" }
+  ,{ "rel" : ["up"] , "href":"http://api.example.com/api/object" }
+  ]
+}

--- a/test/schemas/one_of_ref_links_schema.json
+++ b/test/schemas/one_of_ref_links_schema.json
@@ -1,0 +1,16 @@
+{ "$schema": "http://json-schema.org/draft-04/schema#"
+, "type": "object"
+, "properties":
+  { "links" :
+    { "type" : "array"
+    , "items" :
+      { "type" : "object"
+      , "oneOf" :
+        [ { "$ref" : "self_link_schema.json"}
+        , { "$ref" : "up_link_schema.json" }
+        ]
+      }
+    }
+  }
+}
+

--- a/test/schemas/self_link_schema.json
+++ b/test/schemas/self_link_schema.json
@@ -1,0 +1,17 @@
+{ "$schema": "http://json-schema.org/draft-04/schema#"
+, "type": "object"
+, "properties" :
+  { "rel" :
+    { "type" : "array"
+    , "items" :
+      [ { "type" : "string"
+        , "pattern" : "self"
+        }
+      ]
+    }
+  , "href" :
+    { "type" : "string"
+    }
+  }
+}
+

--- a/test/schemas/up_link_schema.json
+++ b/test/schemas/up_link_schema.json
@@ -1,0 +1,17 @@
+{ "$schema": "http://json-schema.org/draft-04/schema#"
+, "type": "object"
+, "properties" :
+  { "rel" :
+    { "type" : "array"
+    , "items" :
+      [ { "type" : "string"
+        , "pattern" : "up"
+        }
+      ]
+    }
+  , "href" :
+    { "type" : "string"
+    }
+  }
+}
+

--- a/test/test_jsonschema_draft4.rb
+++ b/test/test_jsonschema_draft4.rb
@@ -1146,36 +1146,6 @@ class JSONSchemaDraft4Test < Test::Unit::TestCase
   end
 
 
-  def test_one_of_with_string_patterns
-    schema = {
-      "$schema" => "http://json-schema.org/draft-04/schema#",
-      "oneOf" => [
-        {
-          "properties" => {"a" => {"type" => "string", "pattern" => "foo"}},
-        },
-        {
-          "properties" => {"a" => {"type" => "string", "pattern" => "bar"}},
-        },
-        {
-          "properties" => {"a" => {"type" => "string", "pattern" => "baz"}},
-        }
-      ]
-    }
-
-    data = {"a" => "foo"}
-    assert(JSON::Validator.validate(schema,data))
-
-    data = {"a" => "foobar"}
-    assert(!JSON::Validator.validate(schema,data))
-
-    data = {"a" => "baz"}
-    assert(JSON::Validator.validate(schema,data))
-
-    data = {"a" => 5}
-    assert(!JSON::Validator.validate(schema,data))
-  end
-
-
   def test_not
     # Start with a simple not
     schema = {

--- a/test/test_one_of.rb
+++ b/test/test_one_of.rb
@@ -1,0 +1,42 @@
+require 'test/unit'
+require File.dirname(__FILE__) + '/../lib/json-schema'
+
+class OneOfTest < Test::Unit::TestCase
+  def test_one_of_links_schema
+    schema = File.join(File.dirname(__FILE__),"schemas/one_of_ref_links_schema.json")
+    data = File.join(File.dirname(__FILE__),"data/one_of_ref_links_data.json")
+    errors = JSON::Validator.fully_validate(schema,data, :errors_as_objects => true)
+    assert(errors.empty?, errors.map{|e| e[:message] }.join("\n"))
+  end
+
+
+  def test_one_of_with_string_patterns
+    schema = {
+      "$schema" => "http://json-schema.org/draft-04/schema#",
+      "oneOf" => [
+        {
+          "properties" => {"a" => {"type" => "string", "pattern" => "foo"}},
+        },
+        {
+          "properties" => {"a" => {"type" => "string", "pattern" => "bar"}},
+        },
+        {
+          "properties" => {"a" => {"type" => "string", "pattern" => "baz"}},
+        }
+      ]
+    }
+
+    data = {"a" => "foo"}
+    assert(JSON::Validator.validate(schema,data))
+
+    data = {"a" => "foobar"}
+    assert(!JSON::Validator.validate(schema,data))
+
+    data = {"a" => "baz"}
+    assert(JSON::Validator.validate(schema,data))
+
+    data = {"a" => 5}
+    assert(!JSON::Validator.validate(schema,data))
+  end
+
+end


### PR DESCRIPTION
I found some issues with oneOf that wouldn't validate some schemas I was expecting to pass. In trying to get my schemas to pass I ended up refactoring the oneOf attribute's logic.

Existing oneOf tests still pass along with additional tests I added.

See the comment on 8874569 as I believe there is possible future refactoring to be done to make the `JSON::Schema::Validator#validate` method return true/false.
