### PR TITLE
Fix logic error in format validation

### DIFF
--- a/lib/json-schema/attributes/format.rb
+++ b/lib/json-schema/attributes/format.rb
@@ -2,12 +2,13 @@ module JSON
   class Schema
     class FormatAttribute < Attribute
       def self.validate(current_schema, data, fragments, processor, validator, options = {})
+        return if data.nil?
+
         case current_schema.schema['format']
 
         # Timestamp in restricted ISO-8601 YYYY-MM-DDThh:mm:ssZ with optional decimal fraction of the second
         when 'date-time'
           error_message = "The property '#{build_fragment(fragments)}' must be a date/time in the ISO-8601 format of YYYY-MM-DDThh:mm:ssZ or YYYY-MM-DDThh:mm:ss.ssZ"
-          validation_error(processor, error_message, fragments, current_schema, self, options[:record_errors]) and return if !data.is_a?(String)
           r = Regexp.new('^\d\d\d\d-\d\d-\d\dT(\d\d):(\d\d):(\d\d)([\.,]\d+)?(Z|[+-](\d\d)(:?\d\d)?)?$')
           if (m = r.match(data))
             parts = data.split("T")
@@ -33,7 +34,6 @@ module JSON
         # Date in the format of YYYY-MM-DD
         when 'date'
           error_message = "The property '#{build_fragment(fragments)}' must be a date in the format of YYYY-MM-DD"
-          validation_error(processor, error_message, fragments, current_schema, self, options[:record_errors]) and return if !data.is_a?(String)
           r = Regexp.new('^\d\d\d\d-\d\d-\d\d$')
           if (m = r.match(data))
             begin
@@ -50,7 +50,6 @@ module JSON
         # Time in the format of HH:MM:SS
         when 'time'
           error_message = "The property '#{build_fragment(fragments)}' must be a time in the format of hh:mm:ss"
-          validation_error(processor, error_message, fragments, current_schema, self, options[:record_errors]) and return if !data.is_a?(String)
           r = Regexp.new('^(\d\d):(\d\d):(\d\d)$')
           if (m = r.match(data))
             validation_error(processor, error_message, fragments, current_schema, self, options[:record_errors]) and return if m[1].to_i > 23
@@ -64,7 +63,6 @@ module JSON
         # IPv4 in dotted-quad format
         when 'ip-address', 'ipv4'
           error_message = "The property '#{build_fragment(fragments)}' must be a valid IPv4 address"
-          validation_error(processor, error_message, fragments, current_schema, self, options[:record_errors]) and return if !data.is_a?(String)
           r = Regexp.new('^(\d+){1,3}\.(\d+){1,3}\.(\d+){1,3}\.(\d+){1,3}$')
           if (m = r.match(data))
             1.upto(4) do |x|
@@ -78,7 +76,6 @@ module JSON
         # IPv6 in standard format (including abbreviations)
         when 'ipv6'
           error_message = "The property '#{build_fragment(fragments)}' must be a valid IPv6 address"
-          validation_error(processor, error_message, fragments, current_schema, self, options[:record_errors]) and return if !data.is_a?(String)
           r = Regexp.new('^[a-f0-9:]+$')
           if (m = r.match(data))
             # All characters are valid, now validate structure


### PR DESCRIPTION
If you want to raise an error `if !data.is_a?(String)`, you can't wrap that code in a `if data.is_a?(String)` block...
