### PR TITLE
Make hashes in arrays indifferent to string/symbol keys

### DIFF
--- a/lib/json-schema/schema.rb
+++ b/lib/json-schema/schema.rb
@@ -56,6 +56,10 @@ module JSON
         schema.keys.each do |key|
           add_indifferent_access(schema[key])
         end
+      elsif schema.is_a?(Array)
+        schema.each do |schema_item|
+          add_indifferent_access(schema_item)
+        end
       end
     end
 

--- a/test/test_ruby_schema.rb
+++ b/test/test_ruby_schema.rb
@@ -35,4 +35,34 @@ class RubySchemaTest < Test::Unit::TestCase
 
     assert(JSON::Validator.validate(schema, data))
   end
+
+  def test_symbol_keys_in_hash_within_array
+    schema = {
+      type: 'object',
+      properties: {
+        a: {
+          type: "array",
+          items: [
+            {
+              properties: {
+                b: {
+                  type: "integer"
+                }
+              }
+            }
+          ]
+        }
+      }
+    }
+
+    data = {
+      a: [
+        {
+          b: 1
+        }
+      ]
+    }
+
+    assert(JSON::Validator.validate(schema, data, :validate_schema => true))
+  end
 end


### PR DESCRIPTION
JSON::Schema.add_indifferent_access was only able to recurse into
hashes directly contained within another hash; as soon as it found a
value which was not a hash it stopped. This meant that hashes within
arrays were not being made indifferent to the key type, and so data
with symbol keys in a hash in an array were failing validation when
they should have been valid.

This commit adds a minimal test for this case and fixes #104.
We think that #104 is a duplicate of #101 and #94 so those issues are
likely to be fixed by this as well.
