### PR TITLE
Fix `list:true` when referencing a cached schema

### DIFF
--- a/lib/json-schema/validator.rb
+++ b/lib/json-schema/validator.rb
@@ -609,6 +609,13 @@ module JSON
             Validator.add_schema(schema)
           else
             schema = Validator.schemas[schema_uri.to_s]
+            if @options[:list] && @options[:fragment].nil?
+              schema = schema_to_list(schema.schema)
+              schema_uri = URI.parse(fake_uri(serialize(schema)))
+              schema = JSON::Schema.new(schema, schema_uri, @options[:version])
+              Validator.add_schema(schema)
+            end
+            schema
           end
         end
       elsif schema.is_a?(Hash)

--- a/test/test_jsonschema_draft4.rb
+++ b/test/test_jsonschema_draft4.rb
@@ -867,6 +867,24 @@ class JSONSchemaDraft4Test < Test::Unit::TestCase
     assert(!JSON::Validator.validate(schema,data,:list => true))
   end
 
+  def test_list_option_reusing_schemas
+    schema_hash = {
+      "$schema" => "http://json-schema.org/draft-04/schema#",
+      "type" => "object",
+      "properties" => { "a" => { "type" => "integer" } }
+    }
+
+    uri = URI.parse('http://example.com/item')
+    schema = JSON::Schema.new(schema_hash, uri)
+    JSON::Validator.add_schema(schema)
+
+    data = {"a" => 1}
+    assert(JSON::Validator.validate(uri.to_s, data))
+
+    data = [{"a" => 1}]
+    assert(JSON::Validator.validate(uri.to_s, data, :list => true))
+  end
+
 
   def test_self_reference
     schema = {


### PR DESCRIPTION
When using the `list: true` option, if the schema has already been cached in `Validator.schemas`, json-schema would not wrap the schema in `{ "type": "array", "items": ... }` as expected.

Test included to demonstrate the failure; the fix was to use `fake_uri` as is done elsewhere to generate an identifier for the wrapper schema. I didn't add a test to the `test_jsonschema_draft3` file, as this appears to be an identical code path, so the duplication shouldn't be necessary AFAICT.
