### PR TITLE
Remove deprecated :rubygems source from Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source :rubygems
+source "https://rubygems.org"
 
 gemspec
 


### PR DESCRIPTION
This is triggering a security-related deprecation warning:

```
  The source :rubygems is deprecated because HTTP requests are insecure.
  Please change your source to 'https://rubygems.org' if possible, or 'http://rubygems.org' if not.
```
