### PR TITLE
Stopped draft3 from registering itself as the default validator

### DIFF
--- a/lib/json-schema/validators/draft3.rb
+++ b/lib/json-schema/validators/draft3.rb
@@ -31,7 +31,6 @@ module JSON
       end
       
       JSON::Validator.register_validator(self.new)
-      JSON::Validator.register_default_validator(self.new)
     end
     
   end


### PR DESCRIPTION
Draft4 also registers itself as default, so which one ends up as default depends on which one gets loaded first! (Surely there should be only one default registered?)
