### PR TITLE
Fix bad ref test for proxy support

### DIFF
--- a/test/test_bad_schema_ref.rb
+++ b/test/test_bad_schema_ref.rb
@@ -25,7 +25,7 @@ class BadSchemaRefTest < Test::Unit::TestCase
     }
 
     data = [1,2,3]
-    assert_raise(SocketError) do
+    assert_raise(SocketError, OpenURI::HTTPError) do
       JSON::Validator.validate(schema,data)
     end
   end


### PR DESCRIPTION
If you run behind a proxy, you won't get a socket error, you'll get an
OpenURI::HTTPError instead (because the proxy will return a 503).  That's
perfectly acceptable, too.
