### PR TITLE
Add support for `"required": false` while using draft3 with strict mode

### DIFF
--- a/lib/json-schema/attributes/properties.rb
+++ b/lib/json-schema/attributes/properties.rb
@@ -15,8 +15,8 @@ module JSON
               data[property.to_s] = (default.is_a?(Hash) ? default.clone : default)
             end
 
-
-            if (property_schema['required'] || options[:strict] == true) && !data.has_key?(property.to_s) && !data.has_key?(property.to_sym)
+            if property_schema.fetch('required') { options[:strict] } &&
+               !data.has_key?(property.to_s) && !data.has_key?(property.to_sym)
               message = "The property '#{build_fragment(fragments)}' did not contain a required property of '#{property}'"
               validation_error(processor, message, fragments, current_schema, self, options[:record_errors])
             end

--- a/test/test_jsonschema_draft3.rb
+++ b/test/test_jsonschema_draft3.rb
@@ -503,6 +503,25 @@ class JSONSchemaDraft3Test < Test::Unit::TestCase
     assert(!JSON::Validator.validate(schema,data,:strict => true))
   end
 
+  def test_strict_properties_required_props
+    schema = {
+      "$schema" => "http://json-schema.org/draft-03/schema#",
+      "properties" => {
+        "a" => {"type" => "string", "required" => true},
+        "b" => {"type" => "string", "required" => false}
+      }
+    }
+
+    data = {"a" => "a"}
+    assert(JSON::Validator.validate(schema,data,:strict => true))
+
+    data = {"b" => "b"}
+    assert(!JSON::Validator.validate(schema,data,:strict => true))
+
+    data = {"a" => "a", "b" => "b"}
+    assert(JSON::Validator.validate(schema,data,:strict => true))
+  end
+
   def test_strict_properties_additional_props
     schema = {
       "$schema" => "http://json-schema.org/draft-03/schema#",


### PR DESCRIPTION
Using strict mode currently only allows optional properties through "additionalProperties" and "patternProperties". In draft 3, one could also use `"required": false` to explicitly mark a property as optional; this change makes that possible within strict mode.
