### PR TITLE
Added codeclimate badge to readme

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -1,4 +1,5 @@
 !https://travis-ci.org/hoxworth/json-schema.svg?branch=master!:https://travis-ci.org/hoxworth/json-schema
+!https://codeclimate.com/github/hoxworth/json-schema/badges/gpa.svg!:https://codeclimate.com/github/hoxworth/json-schema
 
 h1. Ruby JSON Schema Validator
 


### PR DESCRIPTION
I think code climate might be useful.

I did try setting up code coverage in code climate as well (ie. make the travis build run simplecov, push the results to code climate and then code climate shows you coverage statistics along side code metrics) but I believe only the owner of the repo can do that (in code climate)
