### PR TITLE
Unescape ref fragment pointers

### DIFF
--- a/lib/json-schema/attributes/ref.rb
+++ b/lib/json-schema/attributes/ref.rb
@@ -49,6 +49,7 @@ module JSON
           fragment_path = ''
           fragments.each do |fragment|
             if fragment && fragment != ''
+              fragment = URI.unescape(fragment.gsub('~0', '~').gsub('~1', '/'))
               if target_schema.is_a?(Array)
                 target_schema = target_schema[fragment.to_i]
               else

--- a/test/test_common_test_suite.rb
+++ b/test/test_common_test_suite.rb
@@ -11,11 +11,9 @@ class CommonTestSuiteTest < Test::Unit::TestCase
     "draft3/disallow.json",
     "draft3/optional/format.json",
     "draft3/optional/jsregex.json",
-    "draft3/ref.json",
     "draft3/refRemote.json",
     "draft4/dependencies.json",
     "draft4/optional/format.json",
-    "draft4/ref.json",
     "draft4/refRemote.json",
   ]
 


### PR DESCRIPTION
The `~0` and `~1` syntax are specified in the JSON Pointer draft: http://tools.ietf.org/html/draft-ietf-appsawg-json-pointer-07#section-3

The common suite tests `draft3/ref.json` and `draft4/ref.json` now pass.
