### PR TITLE
Enable coveralls + simplecov coverage reports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ pkg
 /Gemfile.lock
 .bundle
 .idea
+/coverage

--- a/.simplecov
+++ b/.simplecov
@@ -1,0 +1,10 @@
+require 'coveralls'
+
+SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
+  SimpleCov::Formatter::HTMLFormatter,
+  Coveralls::SimpleCov::Formatter
+]
+
+SimpleCov.start do
+  add_filter '/test/'
+end

--- a/Gemfile
+++ b/Gemfile
@@ -4,4 +4,5 @@ gemspec
 
 group :development do
   gem "rake"
+  gem "coveralls", require: false
 end

--- a/test/test_all_of_ref_schema.rb
+++ b/test/test_all_of_ref_schema.rb
@@ -1,5 +1,4 @@
-require 'test/unit'
-require File.dirname(__FILE__) + '/../lib/json-schema'
+require_relative 'test_helper'
 
 class AllOfRefSchemaTest < Test::Unit::TestCase
   def test_all_of_ref_schema_fails

--- a/test/test_any_of_ref_schema.rb
+++ b/test/test_any_of_ref_schema.rb
@@ -1,5 +1,4 @@
-require 'test/unit'
-require File.dirname(__FILE__) + '/../lib/json-schema'
+require_relative 'test_helper'
 
 class AnyOfRefSchemaTest < Test::Unit::TestCase
   def test_any_of_ref_schema

--- a/test/test_bad_schema_ref.rb
+++ b/test/test_bad_schema_ref.rb
@@ -1,6 +1,5 @@
-require 'test/unit'
+require_relative 'test_helper'
 require 'socket'
-require File.dirname(__FILE__) + '/../lib/json-schema'
 
 class BadSchemaRefTest < Test::Unit::TestCase
 

--- a/test/test_common_test_suite.rb
+++ b/test/test_common_test_suite.rb
@@ -1,5 +1,4 @@
-require 'test/unit'
-require File.expand_path('../../lib/json-schema', __FILE__)
+require_relative 'test_helper'
 
 class CommonTestSuiteTest < Test::Unit::TestCase
   TEST_DIR = File.expand_path('../test-suite/tests', __FILE__)

--- a/test/test_custom_format.rb
+++ b/test/test_custom_format.rb
@@ -1,6 +1,5 @@
 # encoding: utf-8
-require 'test/unit'
-require File.dirname(__FILE__) + '/../lib/json-schema'
+require_relative 'test_helper'
 
 class JSONSchemaCustomFormatTest < Test::Unit::TestCase
   def setup

--- a/test/test_extended_schema.rb
+++ b/test/test_extended_schema.rb
@@ -1,5 +1,4 @@
-require 'test/unit'
-require File.dirname(__FILE__) + '/../lib/json-schema'
+require_relative 'test_helper'
 
 class BitwiseAndAttribute < JSON::Schema::Attribute
   def self.validate(current_schema, data, fragments, processor, validator, options = {})

--- a/test/test_extends_and_additionalProperties.rb
+++ b/test/test_extends_and_additionalProperties.rb
@@ -1,5 +1,4 @@
-require 'test/unit'
-require File.dirname(__FILE__) + '/../lib/json-schema'
+require_relative 'test_helper'
 
 class ExtendsNestedTest < Test::Unit::TestCase
 

--- a/test/test_files_v3.rb
+++ b/test/test_files_v3.rb
@@ -1,5 +1,4 @@
-require 'test/unit'
-require File.dirname(__FILE__) + '/../lib/json-schema'
+require_relative 'test_helper'
 
 class JSONSchemaTest < Test::Unit::TestCase
 

--- a/test/test_fragment_resolution.rb
+++ b/test/test_fragment_resolution.rb
@@ -1,5 +1,4 @@
-require 'test/unit'
-require File.dirname(__FILE__) + '/../lib/json-schema'
+require_relative 'test_helper'
 
 class FragmentResolution < Test::Unit::TestCase
   def test_fragment_resolution

--- a/test/test_fragment_validation_with_ref.rb
+++ b/test/test_fragment_validation_with_ref.rb
@@ -1,5 +1,4 @@
-require File.expand_path('../test_helper', __FILE__)
-require 'json-schema'
+require_relative 'test_helper'
 
 class FragmentValidationWithRef < Test::Unit::TestCase
   def whole_schema

--- a/test/test_full_validation.rb
+++ b/test/test_full_validation.rb
@@ -1,5 +1,4 @@
-require 'test/unit'
-require File.dirname(__FILE__) + '/../lib/json-schema'
+require_relative 'test_helper'
 
 class JSONFullValidation < Test::Unit::TestCase
     

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,2 +1,5 @@
+require 'simplecov' unless ENV['COVERAGE'] == 'false'
 require 'test/unit'
+
 $:.unshift(File.expand_path('../../lib', __FILE__))
+require 'json-schema'

--- a/test/test_jsonschema_draft1.rb
+++ b/test/test_jsonschema_draft1.rb
@@ -1,5 +1,4 @@
-require 'test/unit'
-require File.dirname(__FILE__) + '/../lib/json-schema'
+require_relative 'test_helper'
 
 class JSONSchemaDraft1Test < Test::Unit::TestCase
   def test_types

--- a/test/test_jsonschema_draft2.rb
+++ b/test/test_jsonschema_draft2.rb
@@ -1,5 +1,4 @@
-require 'test/unit'
-require File.dirname(__FILE__) + '/../lib/json-schema'
+require_relative 'test_helper'
 
 class JSONSchemaDraft2Test < Test::Unit::TestCase
   def test_types

--- a/test/test_jsonschema_draft3.rb
+++ b/test/test_jsonschema_draft3.rb
@@ -1,6 +1,5 @@
 # encoding: utf-8
-require 'test/unit'
-require File.dirname(__FILE__) + '/../lib/json-schema'
+require_relative 'test_helper'
 
 class JSONSchemaDraft3Test < Test::Unit::TestCase
   def test_types

--- a/test/test_jsonschema_draft4.rb
+++ b/test/test_jsonschema_draft4.rb
@@ -1,6 +1,5 @@
 # encoding: utf-8
-require 'test/unit'
-require File.dirname(__FILE__) + '/../lib/json-schema'
+require_relative 'test_helper'
 
 class JSONSchemaDraft4Test < Test::Unit::TestCase
   def test_types

--- a/test/test_list_option.rb
+++ b/test/test_list_option.rb
@@ -1,5 +1,4 @@
-require 'test/unit'
-require File.dirname(__FILE__) + '/../lib/json-schema'
+require_relative 'test_helper'
 
 class ListOptionTest < Test::Unit::TestCase
   def test_list_option_reusing_schemas

--- a/test/test_minitems.rb
+++ b/test/test_minitems.rb
@@ -1,5 +1,4 @@
-require 'test/unit'
-require File.dirname(__FILE__) + '/../lib/json-schema'
+require_relative 'test_helper'
 
 class MinItemsTest < Test::Unit::TestCase
   def test_minitems_nils
@@ -8,7 +7,6 @@ class MinItemsTest < Test::Unit::TestCase
       "minItems" => 1,
       "items" => { "type" => "object" }
     }
-    data = [nil]
 
     errors = JSON::Validator.fully_validate(schema, [nil])
     assert_equal(errors.length, 1)

--- a/test/test_one_of.rb
+++ b/test/test_one_of.rb
@@ -1,5 +1,4 @@
-require 'test/unit'
-require File.dirname(__FILE__) + '/../lib/json-schema'
+require_relative 'test_helper'
 
 class OneOfTest < Test::Unit::TestCase
   def test_one_of_links_schema

--- a/test/test_ruby_schema.rb
+++ b/test/test_ruby_schema.rb
@@ -1,5 +1,4 @@
-require 'test/unit'
-require File.dirname(__FILE__) + '/../lib/json-schema'
+require_relative 'test_helper'
 
 class RubySchemaTest < Test::Unit::TestCase
   def test_string_keys

--- a/test/test_schema_type_attribute.rb
+++ b/test/test_schema_type_attribute.rb
@@ -1,5 +1,4 @@
-require 'test/unit'
-require File.dirname(__FILE__) + '/../lib/json-schema'
+require_relative 'test_helper'
 
 class TestSchemaTypeAttribute < Test::Unit::TestCase
   def test_type_of_data

--- a/test/test_schema_validation.rb
+++ b/test/test_schema_validation.rb
@@ -1,6 +1,5 @@
-require 'test/unit'
+require_relative 'test_helper'
 require 'tmpdir'
-require File.dirname(__FILE__) + '/../lib/json-schema'
 
 class JSONSchemaValidation < Test::Unit::TestCase
   def valid_schema_v3


### PR DESCRIPTION
This updates every test to just require a common `test_helper`, which boots SimpleCov with two reporters: one to spit out a local report in `coverage/index.html`, and another to submit to [Coveralls](http://coveralls.io).

I sent this PR to my own fork first so we could get an example of the result:
1. https://coveralls.io/r/pd/json-schema -- repo page showing latest builds and current status
2. https://coveralls.io/builds/1389205 -- actual build report

@iainbeeston [mentioned](https://github.com/hoxworth/json-schema/pull/141#issuecomment-60557532) getting the report coverage into codeclimate, which might be a better choice since we're already using it. I mostly just wanted a POC to validate that we could get this report generating at all.

The only benefit to coveralls over codeclimate is that coveralls will retain per-job metrics, so you can see that, for example, coverage on JRuby is 79.03% but on MRI it's 86.87%.

If @hoxworth sets up the codeclimate stuffs from #141, I'll swap this PR over to use that instead.
