### PR TITLE
Store static regexps in constants for re-use

### DIFF
--- a/lib/json-schema/attributes/formats/date.rb
+++ b/lib/json-schema/attributes/formats/date.rb
@@ -3,7 +3,7 @@ require 'json-schema/attribute'
 module JSON
   class Schema
     class DateFormat < FormatAttribute
-      REGEXP = Regexp.new('^\d\d\d\d-\d\d-\d\d$')
+      REGEXP = /\A\d{4}-\d{2}-\d{2}\z/
 
       def self.validate(current_schema, data, fragments, processor, validator, options = {})
         if data.is_a?(String)

--- a/lib/json-schema/attributes/formats/date_time.rb
+++ b/lib/json-schema/attributes/formats/date_time.rb
@@ -3,7 +3,7 @@ require 'json-schema/attribute'
 module JSON
   class Schema
     class DateTimeFormat < FormatAttribute
-      REGEXP = Regexp.new('^\d\d\d\d-\d\d-\d\dT(\d\d):(\d\d):(\d\d)([\.,]\d+)?(Z|[+-](\d\d)(:?\d\d)?)?$')
+      REGEXP = /\A\d{4}-\d{2}-\d{2}T(\d{2}):(\d{2}):(\d{2})([\.,]\d+)?(Z|[+-](\d{2})(:?\d{2})?)?\z/
 
       def self.validate(current_schema, data, fragments, processor, validator, options = {})
         # Timestamp in restricted ISO-8601 YYYY-MM-DDThh:mm:ssZ with optional decimal fraction of the second

--- a/lib/json-schema/attributes/formats/time.rb
+++ b/lib/json-schema/attributes/formats/time.rb
@@ -3,7 +3,7 @@ require 'json-schema/attribute'
 module JSON
   class Schema
     class TimeFormat < FormatAttribute
-      REGEXP = Regexp.new('^(\d\d):(\d\d):(\d\d)$')
+      REGEXP = /\A(\d{2}):(\d{2}):(\d{2})\z/
 
       def self.validate(current_schema, data, fragments, processor, validator, options = {})
         if data.is_a?(String)

--- a/test/test_jsonschema_draft1.rb
+++ b/test/test_jsonschema_draft1.rb
@@ -639,6 +639,10 @@ class JSONSchemaDraft1Test < Test::Unit::TestCase
     assert(!JSON::Validator.validate(schema,data,:version => :draft1))
     data = {"a" => "12:00:00b"}
     assert(!JSON::Validator.validate(schema,data,:version => :draft1))
+    data = {"a" => "12:00:00"}
+    assert(JSON::Validator.validate(schema,data,:version => :draft1))
+    data = {"a" => "12:00:00\nabc"}
+    assert(!JSON::Validator.validate(schema,data,:version => :draft1))
   end
 
 
@@ -659,6 +663,8 @@ class JSONSchemaDraft1Test < Test::Unit::TestCase
     data = {"a" => "2010-01-1"}
     assert(!JSON::Validator.validate(schema,data,:version => :draft1))
     data = {"a" => "2010-01-01n"}
+    assert(!JSON::Validator.validate(schema,data,:version => :draft1))
+    data = {"a" => "2010-01-01\nabc"}
     assert(!JSON::Validator.validate(schema,data,:version => :draft1))
   end
 
@@ -683,6 +689,8 @@ class JSONSchemaDraft1Test < Test::Unit::TestCase
     data = {"a" => "2010-01-01T12:00:00z"}
     assert(!JSON::Validator.validate(schema,data,:version => :draft1))
     data = {"a" => "2010-01-0112:00:00Z"}
+    assert(!JSON::Validator.validate(schema,data,:version => :draft1))
+    data = {"a" => "2010-01-01T12:00:00Z\nabc"}
     assert(!JSON::Validator.validate(schema,data,:version => :draft1))
   end
 

--- a/test/test_jsonschema_draft2.rb
+++ b/test/test_jsonschema_draft2.rb
@@ -711,6 +711,8 @@ class JSONSchemaDraft2Test < Test::Unit::TestCase
     assert(!JSON::Validator.validate(schema,data,:version => :draft2))
     data = {"a" => "12:00:00b"}
     assert(!JSON::Validator.validate(schema,data,:version => :draft2))
+    data = {"a" => "12:00:00\nabc"}
+    assert(!JSON::Validator.validate(schema,data,:version => :draft2))
   end
 
 
@@ -731,6 +733,8 @@ class JSONSchemaDraft2Test < Test::Unit::TestCase
     data = {"a" => "2010-01-1"}
     assert(!JSON::Validator.validate(schema,data,:version => :draft2))
     data = {"a" => "2010-01-01n"}
+    assert(!JSON::Validator.validate(schema,data,:version => :draft2))
+    data = {"a" => "2010-01-01\nabc"}
     assert(!JSON::Validator.validate(schema,data,:version => :draft2))
   end
 
@@ -755,6 +759,8 @@ class JSONSchemaDraft2Test < Test::Unit::TestCase
     data = {"a" => "2010-01-01T12:00:00z"}
     assert(!JSON::Validator.validate(schema,data,:version => :draft2))
     data = {"a" => "2010-01-0112:00:00Z"}
+    assert(!JSON::Validator.validate(schema,data,:version => :draft2))
+    data = {"a" => "2010-01-01T12:00:00Z\nabc"}
     assert(!JSON::Validator.validate(schema,data,:version => :draft2))
   end
 

--- a/test/test_jsonschema_draft3.rb
+++ b/test/test_jsonschema_draft3.rb
@@ -1011,6 +1011,8 @@ class JSONSchemaDraft3Test < Test::Unit::TestCase
     assert(!JSON::Validator.validate(schema,data))
     data = {"a" => "12:00:00b"}
     assert(!JSON::Validator.validate(schema,data))
+    data = {"a" => "12:00:00\nabc"}
+    assert(!JSON::Validator.validate(schema,data))
   end
 
 
@@ -1032,6 +1034,8 @@ class JSONSchemaDraft3Test < Test::Unit::TestCase
     data = {"a" => "2010-01-1"}
     assert(!JSON::Validator.validate(schema,data))
     data = {"a" => "2010-01-01n"}
+    assert(!JSON::Validator.validate(schema,data))
+    data = {"a" => "2010-01-01\nabc"}
     assert(!JSON::Validator.validate(schema,data))
   end
 
@@ -1061,6 +1065,8 @@ class JSONSchemaDraft3Test < Test::Unit::TestCase
     data = {"a" => "2010-01-01T12:00:00z"}
     assert(!JSON::Validator.validate(schema,data))
     data = {"a" => "2010-01-0112:00:00Z"}
+    assert(!JSON::Validator.validate(schema,data))
+    data = {"a" => "2010-01-01T12:00:00.1Z\nabc"}
     assert(!JSON::Validator.validate(schema,data))
 
     # test with a specific timezone


### PR DESCRIPTION
Since they're static, there's no need to re-compile it every time.

Microbenchmark:

``` ruby
require 'benchmark'

STR = '2010-01-01T12:00:00Z'
RGXSTR = '^\d\d\d\d-\d\d-\d\dT(\d\d):(\d\d):(\d\d)([\.,]\d+)?(Z|[+-](\d\d)(:?\d\d)?)?$'
RGX = Regexp.new(RGXSTR)

N = 10_000

Benchmark.bmbm do |x|
  x.report('re-compiled') do
    N.times { Regexp.new(RGXSTR).match(STR) }
  end

  x.report('precompiled') do
    N.times { RGX.match(STR) }
  end
end

__END__
~ [chruby:2.1.1] » ruby bench.rb
Rehearsal -----------------------------------------------
re-compiled   0.770000   0.000000   0.770000 (  0.779001)
precompiled   0.010000   0.000000   0.010000 (  0.011617)
-------------------------------------- total: 0.780000sec

                  user     system      total        real
re-compiled   0.760000   0.000000   0.760000 (  0.766040)
precompiled   0.010000   0.000000   0.010000 (  0.008398)
```

I've got an app that is using draft3 + a lot of `format: "date"` and this made a decent dent in the runtime for tests validating the API.
