### PR TITLE
Fix draft3 `disallow` validation

### DIFF
--- a/lib/json-schema/attributes/type.rb
+++ b/lib/json-schema/attributes/type.rb
@@ -32,7 +32,7 @@ module JSON
             pre_validation_error_count = validation_errors(processor).count
 
             begin
-              schema.validate(data,fragments,processor,options)
+              schema.validate(data,fragments,processor,options.merge(:disallow => false))
               valid = true
             rescue ValidationError
               # We don't care that these schemas don't validate - we only care that one validated

--- a/test/test_common_test_suite.rb
+++ b/test/test_common_test_suite.rb
@@ -10,7 +10,6 @@ class CommonTestSuiteTest < Test::Unit::TestCase
   # you can replace `:all` with an array containing the names of individual
   # tests to skip.
   IGNORED_TESTS = Hash.new { |h,k| h[k] = [] }.merge({
-    "draft3/disallow.json" => :all,
     "draft3/optional/format.json" => :all,
     "draft3/optional/jsregex.json" => [
       "ECMA 262 regex dialect recognition/ECMA 262 has no support for lookbehind",


### PR DESCRIPTION
Only two tests were failing in the `disallow` test for draft3. The underlying issue was the recursive use of validation in TypeAttribute: if `options[:disallow]` was true, it would continue to be passed to the inner type validations, which would invert the actual result.
