### PR TITLE
Escape spaces in URIs to make them parsable

### DIFF
--- a/lib/json-schema/uri/file.rb
+++ b/lib/json-schema/uri/file.rb
@@ -28,7 +28,7 @@ module URI
     end
 
     def open(*rest, &block)
-      ::File.open(self.path, *rest, &block)
+      ::File.open(self.path.gsub('%20', ' '), *rest, &block)
     end
 
     @@schemes['FILE'] = File

--- a/lib/json-schema/validator.rb
+++ b/lib/json-schema/validator.rb
@@ -581,6 +581,9 @@ module JSON
     end
 
     def normalized_uri(data)
+      # URI cannot deal with spaces in path, encode them by %20 but escpace nothing else
+      # or lookup for existing schemas breaks (# gets encoded as %23 by URI.escape)
+      data = data.gsub(' ', '%20')
       uri = URI.parse(data)
       if uri.relative?
         # Check for absolute path


### PR DESCRIPTION
Fixes #100 
normalized_uri passes the given data to URI for parsing which is not happy with spaces that are not encoded.
