### PR TITLE
Use RFC 2606 reserved invalid DNS name in tests.

### DIFF
--- a/test/test_bad_schema_ref.rb
+++ b/test/test_bad_schema_ref.rb
@@ -29,7 +29,7 @@ class BadSchemaRefTest < Minitest::Test
     schema = {
       "$schema" => "http://json-schema.org/draft-04/schema#",
       "type" => "array",
-      "items" => { "$ref" => "http://ppcheesecheseunicornnuuuurrrrr.com/json.schema"}
+      "items" => { "$ref" => "http://ppcheesecheseunicornnuuuurrrrr.example.invalid/json.schema"}
     }
 
     data = [1,2,3]


### PR DESCRIPTION
This test used a DNS name which, while currently not existing, is not actually reserved. This can manifest as a test failure on poorly configured (like Time Warner Cable) networks. This changes said DNS name to one using a reserved invalid top level name as specified in RFC 2606.

Here's what a failure looks like on TWC DNS because of their inane NXDOMAIN hijacking to serve ads:

```
  1) Failure:
BadSchemaRefTest#test_bad_host_ref [/Users/ggironda/Repositories/json-schema/test/test_bad_schema_ref.rb:36]:
[SocketError, OpenURI::HTTPError] exception expected, not
Class: <JSON::ParserError>
Message: <"757: unexpected token at '<html><head><meta http-equiv=\"refresh\" content=\"0;url=http://www.dnsrsearch.com/index.php?origURL=http://ppcheesecheseunicornnuuuurrrrr.com/json.schema\"/></head><body><script type=\"text/javascript\">window.location=\"http://www.dnsrsearch.com/index.php?origURL=\"+escape(window.location)+\"&r=\"+escape(document.referrer);</script></body></html>'">
---Backtrace---
/usr/local/opt/rbenv/versions/2.0.0-p247/lib/ruby/2.0.0/json/common.rb:155:in `parse'
/usr/local/opt/rbenv/versions/2.0.0-p247/lib/ruby/2.0.0/json/common.rb:155:in `parse'
/Users/ggironda/Repositories/json-schema/lib/json-schema/validator.rb:415:in `parse'
/Users/ggironda/Repositories/json-schema/lib/json-schema/validator.rb:148:in `load_ref_schema'
```
