### PR TITLE
Only stringify schema once

### DIFF
--- a/lib/json-schema/schema.rb
+++ b/lib/json-schema/schema.rb
@@ -6,7 +6,7 @@ module JSON
     attr_accessor :schema, :uri, :validator
 
     def initialize(schema,uri,parent_validator=nil)
-      @schema = self.class.stringify(schema)
+      @schema = schema
       @uri = uri
 
       # If there is an ID on this schema, use it to generate the URI

--- a/lib/json-schema/validator.rb
+++ b/lib/json-schema/validator.rb
@@ -516,6 +516,7 @@ module JSON
           schema_uri = normalized_uri(schema)
           if !self.class.schema_loaded?(schema_uri)
             schema = JSON::Validator.parse(open(schema_uri.to_s).read)
+            schema = JSON::Schema.stringify(schema)
             if @options[:list] && @options[:fragment].nil?
               schema = schema_to_list(schema)
             end
@@ -537,6 +538,7 @@ module JSON
           schema = schema_to_list(schema)
         end
         schema_uri = URI.parse(fake_uuid(serialize(schema)))
+        schema = JSON::Schema.stringify(schema)
         schema = JSON::Schema.new(schema,schema_uri,@options[:version])
         Validator.add_schema(schema)
       else


### PR DESCRIPTION
The stringify step recursively stringifies all keys of the schema. At the moment it is not done once per schema, but over and over again for every sub–schema. Pulling out the stringify step from the schema initialization speeds up schema verification by around 30% on my machine. Tests still pass.
