### PR TITLE
Validator should accept JSON::Schema objects

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -178,6 +178,16 @@ errors = JSON::Validator.fully_validate(schema, data, :errors_as_objects => true
 
 </pre>
 
+h3. Validate against an existing schema instance
+
+If you've already created a <code>JSON::Schema</code> object, it can be significantly faster to re-use it during validation:
+
+<pre>
+schema = JSON::Schema.new({ 'type' => 'array' }, URI.parse('http://example.com/array'))
+JSON::Validator.validate(schema, [])
+JSON::Validator.validate(schema, {})
+</pre>
+
 h3. Validate against a fragment of a supplied schema
 
 <pre>

--- a/lib/json-schema/validator.rb
+++ b/lib/json-schema/validator.rb
@@ -541,6 +541,8 @@ module JSON
         schema = JSON::Schema.stringify(schema)
         schema = JSON::Schema.new(schema,schema_uri,@options[:version])
         Validator.add_schema(schema)
+      elsif schema.is_a?(JSON::Schema)
+        Validator.add_schema(schema)
       else
         raise "Invalid schema - must be either a string or a hash"
       end

--- a/test/test_schema_reuse.rb
+++ b/test/test_schema_reuse.rb
@@ -1,0 +1,12 @@
+require File.expand_path('../test_helper', __FILE__)
+
+class SchemaReuseTest < Minitest::Test
+  def test_validate_schema_with_schema_object
+    schema = JSON::Schema.new({ 'type' => 'array' }, URI.parse('http://example.com/array'))
+
+    assert_valid schema, []
+    assert JSON::Validator.schemas.key?('http://example.com/array#')
+
+    refute_valid schema, {}
+  end
+end


### PR DESCRIPTION
## what

Related to my plans in #182; caching inner schemas is only so useful if we still have to recreate them all for every separate validation call.

`Validator.validate` et al only accept strings or hashes right now, but if I want to validate _a lot_ of JSON, I've probably pre-registered all my schemas, and I'd like to just re-use those pre-existing instances.
## benchmarks

I'm using this benchmark script to ensure things are actually speeding up:

``` ruby
require 'bundler/setup'
require 'json-schema'
require 'benchmark/ips'

S_HASH = {
  'id' => 'http://example.com/foo',
  'type' => 'array',
  'items' => {
    'anyOf' => [{'type' => 'number'}, {'type' => 'string'}]
  }
}

S_INST = JSON::Schema.new(S_HASH, nil)

Benchmark.ips do |x|
  x.config(time: 5, warmup: 2)

  x.report('fresh') do
    JSON::Validator.validate(S_HASH, [1,2,'a','b',3,4])
  end

  x.report('reuse') do
    JSON::Validator.validate(S_INST, [1,2,'a','b',3,4])
  end

  x.compare!
end
```

Results:

```
Calculating -------------------------------------
               fresh   237.000  i/100ms
               reuse   652.000  i/100ms
-------------------------------------------------
               fresh      2.310k (± 3.8%) i/s -     11.613k
               reuse      6.899k (± 3.4%) i/s -     34.556k

Comparison:
               reuse:     6899.4 i/s
               fresh:     2309.6 i/s - 2.99x slower
```
