### PR TITLE
Added a require_all option for validating closer to spec

### DIFF
--- a/VERSION.yml
+++ b/VERSION.yml
@@ -1,3 +1,3 @@
 major: 2
 minor: 4
-patch: 1
+patch: 1.1

--- a/lib/json-schema/attributes/properties.rb
+++ b/lib/json-schema/attributes/properties.rb
@@ -67,7 +67,7 @@ module JSON
       # draft4 relies on its own RequiredAttribute validation at a higher level, rather than
       # as an attribute of individual properties.
       def self.required?(schema, options)
-        options[:strict] == true
+        options[:strict] == true && options[:require_all] == true
       end
     end
   end

--- a/lib/json-schema/validator.rb
+++ b/lib/json-schema/validator.rb
@@ -24,7 +24,8 @@ module JSON
       :errors_as_objects => false,
       :insert_defaults => false,
       :clear_cache => true,
-      :strict => false
+      :strict => false,
+      :require_all => true
     }
     @@validators = {}
     @@default_validator = nil
@@ -43,6 +44,7 @@ module JSON
       @validation_options = @options[:record_errors] ? {:record_errors => true} : {}
       @validation_options[:insert_defaults] = true if @options[:insert_defaults]
       @validation_options[:strict] = true if @options[:strict] == true
+      @validation_options[:require_all] = true if @options[:require_all] == true
 
       @@mutex.synchronize { @base_schema = initialize_schema(schema_data) }
       @original_data = data

--- a/test/test_jsonschema_draft4.rb
+++ b/test/test_jsonschema_draft4.rb
@@ -101,6 +101,29 @@ class JSONSchemaDraft4Test < Minitest::Test
     assert(!JSON::Validator.validate(schema,data,:strict => true))
   end
 
+  def test_strict_require_all_properties
+    schema = {
+        "$schema" => "http://json-schema.org/draft-04/schema#",
+        "required" => ["a"],
+        "properties" => {
+            "a" => {"type" => "string"},
+            "b" => {"type" => "string"}
+        }
+    }
+
+    data = {"a" => "a"}
+    assert(JSON::Validator.validate(schema,data,:strict => true, :require_all => false))
+
+    data = {"b" => "b"}
+    assert(!JSON::Validator.validate(schema,data,:strict => true, :require_all => false))
+
+    data = {"a" => "a", "b" => "b"}
+    assert(JSON::Validator.validate(schema,data,:strict => true, :require_all => false))
+
+    data = {"a" => "a", "b" => "b", "c" => "c"}
+    assert(!JSON::Validator.validate(schema,data,:strict => true, :require_all => false))
+  end
+
   def test_strict_properties_additional_props
     schema = {
       "$schema" => "http://json-schema.org/draft-04/schema#",


### PR DESCRIPTION
Added a require_all option that only validates when all properties in the schema are in the data.

It defaults to true, so the current strict mode behavior is unchanged.

It only changes the behavior of draft4 type schemas. Sorry, I don't know enough to know if I should change the other schemas.

Discussion was started on this issue: https://github.com/ruby-json-schema/json-schema/issues/103