### PR TITLE
Add pry, pry-byebug as development dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,4 +7,6 @@ gem "json", :platforms => :mri_18
 group :development do
   gem "rake"
   gem "minitest", '~> 5.0'
+  gem "pry"
+  gem "pry-byebug", :platforms => [:mri_20, :mri_21]
 end


### PR DESCRIPTION
Basically every time I start working on this library, I go add these two to the Gemfile so that I can step through code and debug things. I think @RST-J uses byebug directly, and this should support that workflow too.

I've added a platform guard on pry-byebug, because it only works on MRI >= 2.0. I've tested this locally on rbx, and travis should hopefully catch any issues with 1.8 and jruby.
