### PR TITLE
Remove unused Schema#base_uri method

### DIFF
--- a/lib/json-schema/schema.rb
+++ b/lib/json-schema/schema.rb
@@ -49,12 +49,6 @@ module JSON
       end
     end
 
-    def base_uri
-      parts = @uri.to_s.split('/')
-      parts.pop
-      parts.join('/') + '/'
-    end
-
     def to_s
       @schema.to_json
     end


### PR DESCRIPTION
This removes an unused method from `JSON::Schema`; there's no test coverage on it, and it's not very clear what it's meant to be used for. The only commit that has ever referenced it is the very first commit to this repo:

``` console
$ git log -S base_uri
commit d1c7b421bbb04d00b06c49e6ebb5ba773d756b12
Author: Kenny Hoxworth <hoxworth@gmail.com>
Date:   Wed Nov 24 15:11:09 2010 -0500

    Initial commit.
```
