### PR TITLE
Tidied the common test suite tests

### DIFF
--- a/test/test_common_test_suite.rb
+++ b/test/test_common_test_suite.rb
@@ -55,8 +55,8 @@ class CommonTestSuiteTest < Minitest::Test
 
         test["tests"].each do |t|
           next if IGNORED_TESTS[rel_file] == :all
-          next if IGNORED_TESTS[rel_file].any? { |test|
-            base_description == test || "#{base_description}/#{t['description']}" == test
+          next if IGNORED_TESTS[rel_file].any? { |ignored|
+            base_description == ignored || "#{base_description}/#{t['description']}" == ignored
           }
 
           err_id = "#{rel_file}: #{base_description}/#{t['description']}"


### PR DESCRIPTION
I've put together 3 small tweaks to the common test suite code. In the order that the commits appear:
1. I've removed an unused variable
2. I've switched to loading the common test suite json files using the json gem, rather than `JSON::Validator.parse`, to insulate us from any bugs in our own parsing code
3. One of the loops was re-redefining the variable `test` inside a loop (it was previously defined outside the loop - so we were shadowing the original value)
