### PR TITLE
Stop running 1.8 on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: "ruby"
 
 rvm:
-  - "1.8"
   - "1.9"
   - "2.0"
   - "2.1"
@@ -21,5 +20,3 @@ matrix:
       gemfile: "gemfiles/Gemfile.yajl-ruby.x"
     - rvm: "2.1"
       gemfile: "gemfiles/Gemfile.uuidtools.x"
-  allow_failures:
-    - rvm: "1.8"

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,0 +1,3 @@
+# Changes in json-schema 3.0
+
+* Support for Ruby 1.8 has been removed; a Ruby 1.9+ compatible runtime is now required.

--- a/Gemfile
+++ b/Gemfile
@@ -2,4 +2,9 @@ source "https://rubygems.org"
 
 gemspec
 
-gem "json", ">= 1.7", :platforms => [:mri_18, :mri_19]
+gem "json", ">= 1.7", :platforms => [:mri_19]
+
+group :development do
+  gem "rake"
+  gem "minitest", '~> 5.0'
+end

--- a/json-schema.gemspec
+++ b/json-schema.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.require_path = "lib"
   s.test_files = Dir[ "test/**/test*", "test/{data,schemas}/*.json" ]
   s.extra_rdoc_files = ["README.textile","LICENSE.md"]
-  s.required_ruby_version = ">= 1.8.7"
+  s.required_ruby_version = ">= 1.9.0"
   s.license = "MIT"
   s.required_rubygems_version = ">= 1.8"
 


### PR DESCRIPTION
There is likely some 1.8-specific code juggling that still remains, but I think this is sufficient for now: we explicitly aren't testing against 1.8 any longer.

I've added a Changelog.md, but didn't put any real thought into its structure or such yet. I figure once there's more than a single line we can re-visit that. =)