### PR TITLE
Remove support for alternate JSON backends

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,10 +16,6 @@ install:
 matrix:
   include:
     - rvm: "2.1"
-      gemfile: "gemfiles/Gemfile.multi_json.x"
-    - rvm: "2.1"
-      gemfile: "gemfiles/Gemfile.yajl-ruby.x"
-    - rvm: "2.1"
       gemfile: "gemfiles/Gemfile.uuidtools.x"
   allow_failures:
     - rvm: "1.8"

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,0 +1,4 @@
+# Changes in json-schema 3.0
+
+* Support for `multi_json` and `yajl-ruby` have been dropped; the standard `json` library,
+  available on all common Ruby implementations, is always used.

--- a/README.textile
+++ b/README.textile
@@ -371,18 +371,6 @@ errors = JSON::Validator.fully_validate(schema, {"a" => "23"})
 
 </pre>
 
-h2. JSON Backends
-
-The JSON Schema library currently supports the <code>json</code> and <code>yajl-ruby</code> backend JSON parsers. If either of these libraries are installed, they will be automatically loaded and used to parse any JSON strings supplied by the user.
-
-If more than one of the supported JSON backends are installed, the <code>yajl-ruby</code> parser is used by default. This can be changed by issuing the following before validation:
-
-<pre>
-JSON::Validator.json_backend = :json
-</pre>
-
-Optionally, the JSON Schema library supports using the MultiJSON library for selecting JSON backends. If the MultiJSON library is installed, it will be autoloaded.
-
 h2. Notes
 
 The 'format' attribute is only validated for the following values:

--- a/lib/json-schema.rb
+++ b/lib/json-schema.rb
@@ -1,16 +1,10 @@
 require 'rubygems'
 
-if Gem::Specification::find_all_by_name('multi_json').any?
-  require 'multi_json'
-
-  # Force MultiJson to load an engine before we define the JSON constant here; otherwise,
-  # it looks for things that are under the JSON namespace that aren't there (since we have defined it here)
-  MultiJson.respond_to?(:adapter) ? MultiJson.adapter : MultiJson.engine
-end
-
+require 'json'
 require 'json-schema/util/array_set'
 require 'json-schema/schema'
 require 'json-schema/validator'
+
 Dir[File.join(File.dirname(__FILE__), "json-schema/attributes/*.rb")].each {|file| require file }
 Dir[File.join(File.dirname(__FILE__), "json-schema/attributes/formats/*.rb")].each {|file| require file }
 Dir[File.join(File.dirname(__FILE__), "json-schema/validators/*.rb")].sort!.each {|file| require file }

--- a/test/test_files_v3.rb
+++ b/test/test_files_v3.rb
@@ -2,10 +2,6 @@ require File.expand_path('../test_helper', __FILE__)
 
 class JSONSchemaTest < Minitest::Test
 
-  #
-  # These tests are ONLY run if there is an appropriate JSON backend parser available
-  #
-
   def test_schema_from_file
     assert_valid schema_fixture_path('good_schema_1.json'), { "a" => 5 }
     refute_valid schema_fixture_path('good_schema_1.json'), { "a" => "bad" }
@@ -18,11 +14,9 @@ class JSONSchemaTest < Minitest::Test
   end
 
   def test_data_from_json
-    if JSON::Validator.json_backend != nil
-      schema = {"$schema" => "http://json-schema.org/draft-03/schema#","type" => "object", "properties" => {"a" => {"type" => "integer"}}}
-      assert_valid schema, %Q({"a": 5}), :json => true
-      refute_valid schema, %Q({"a": "poop"}), :json => true
-    end
+    schema = {"$schema" => "http://json-schema.org/draft-03/schema#","type" => "object", "properties" => {"a" => {"type" => "integer"}}}
+    assert_valid schema, %Q({"a": 5}), :json => true
+    refute_valid schema, %Q({"a": "poop"}), :json => true
   end
 
   def test_both_from_file


### PR DESCRIPTION
See #195; there wasn't broad agreement there, but if you look at the multi_json PR that @iainbeeston linked (https://github.com/intridea/multi_json/pull/113), you can see just how broadly this is happening across the ruby ecosystem right now. With the dropping of support for 1.8 (#205), we have a built-in, not-that-bad JSON library on all supported runtimes, so we should just use that, IMO.

This will have conflicts with #205, since both add a Changelog.md. I assume that one will land first, so I'll rebase later.