### PR TITLE
WebMock is on globally now; no need to disable it

### DIFF
--- a/test/test_schema_loader.rb
+++ b/test/test_schema_loader.rb
@@ -66,7 +66,16 @@ class TestSchemaReader < Minitest::Test
     stub_address_request('this is totally not valid JSON!')
 
     reader = JSON::Schema::Reader.new
-    assert_raises(JSON::ParserError) do
+
+    klass = if defined?(::Yajl)
+              Yajl::ParseError
+            elsif defined?(::MultiJson)
+              MultiJson::ParseError
+            else
+              JSON::ParserError
+            end
+
+    assert_raises(klass) do
       reader.read(ADDRESS_SCHEMA_URI)
     end
   end


### PR DESCRIPTION
Introduced by conflicts in how #175 and #196 juggled webmock usage.

Closes #207.
