### PR TITLE
Refactored parser error code

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -34,4 +34,14 @@ class Minitest::Test
     errors = JSON::Validator.fully_validate(schema, data, options)
     refute_equal([], errors, "#{data.inspect} should be invalid for schema:\n#{schema.inspect}")
   end
+
+  def parser_error
+    if defined?(::Yajl)
+      Yajl::ParseError
+    elsif defined?(::MultiJson)
+      MultiJson::ParseError
+    else
+      JSON::ParserError
+    end
+  end
 end

--- a/test/test_initialize_data.rb
+++ b/test/test_initialize_data.rb
@@ -2,11 +2,6 @@ require File.expand_path('../test_helper', __FILE__)
 
 class InitializeDataTest < Minitest::Test
 
-  def refute_block(&blk)
-    result = blk.call
-    refute(result)
-  end
-
   def test_parse_character_string
     schema = {'type' => 'string'}
     data = 'hello world'
@@ -15,12 +10,8 @@ class InitializeDataTest < Minitest::Test
 
     assert(JSON::Validator.validate(schema, data, :parse_data => false))
 
-    refute_block do
-      begin
-        JSON::Validator.validate(schema, data, :json => true)
-      rescue
-        false
-      end
+    assert_raises(parser_error) do
+      JSON::Validator.validate(schema, data, :json => true)
     end
 
     assert_raises(Errno::ENOENT) { JSON::Validator.validate(schema, data, :uri => true) }
@@ -75,12 +66,8 @@ class InitializeDataTest < Minitest::Test
 
     assert(JSON::Validator.validate(schema, data, :parse_data => false))
 
-    refute_block do
-      begin
-        JSON::Validator.validate(schema, data, :json => true)
-      rescue
-        false
-      end
+    assert_raises(parser_error) do
+      JSON::Validator.validate(schema, data, :json => true)
     end
 
     assert(JSON::Validator.validate(schema, data, :uri => true))
@@ -96,12 +83,8 @@ class InitializeDataTest < Minitest::Test
 
     assert(JSON::Validator.validate(schema, data, :parse_data => false))
 
-    refute_block do
-      begin
-        JSON::Validator.validate(schema, data, :json => true)
-      rescue
-        false
-      end
+    assert_raises(parser_error) do
+      JSON::Validator.validate(schema, data, :json => true)
     end
 
     assert_raises(Timeout::Error) { JSON::Validator.validate(schema, data, :uri => true) }

--- a/test/test_schema_loader.rb
+++ b/test/test_schema_loader.rb
@@ -67,15 +67,7 @@ class TestSchemaReader < Minitest::Test
 
     reader = JSON::Schema::Reader.new
 
-    klass = if defined?(::Yajl)
-              Yajl::ParseError
-            elsif defined?(::MultiJson)
-              MultiJson::ParseError
-            else
-              JSON::ParserError
-            end
-
-    assert_raises(klass) do
+    assert_raises(parser_error) do
       reader.read(ADDRESS_SCHEMA_URI)
     end
   end


### PR DESCRIPTION
As discussed in #208, I've refactored the tests that check for parser errors, such that they work for all json backends, but only catch the parse error specific to that platform.
