### PR TITLE
End single quote in validation error

### DIFF
--- a/lib/json-schema/attributes/properties.rb
+++ b/lib/json-schema/attributes/properties.rb
@@ -57,7 +57,7 @@ module JSON
 
         if diff.size > 0
           properties = data.to_a.map { |(key, _)| key }.join(', ')
-          message = "The property '#{build_fragment(fragments)}' contained undefined properties: '#{properties}"
+          message = "The property '#{build_fragment(fragments)}' contained undefined properties: '#{properties}'"
           validation_error(processor, message, fragments, current_schema, self, options[:record_errors])
         end
       end


### PR DESCRIPTION
A trivial change to clarify the output message for `contained undefined properties`: add the closing single quote.