### PR TITLE
Issue with Fixnum and Float in enum

### DIFF
--- a/lib/json-schema/attributes/enum.rb
+++ b/lib/json-schema/attributes/enum.rb
@@ -5,7 +5,7 @@ module JSON
     class EnumAttribute < Attribute
       def self.validate(current_schema, data, fragments, processor, validator, options = {})
         enum = current_schema.schema['enum']
-        return if enum.any? { |value| data == value }
+        return if enum.include?(data)
 
         values = enum.map { |val|
           case val

--- a/lib/json-schema/attributes/enum.rb
+++ b/lib/json-schema/attributes/enum.rb
@@ -5,7 +5,7 @@ module JSON
     class EnumAttribute < Attribute
       def self.validate(current_schema, data, fragments, processor, validator, options = {})
         enum = current_schema.schema['enum']
-        return if enum.include?(data)
+        return if enum.any? { |value| data == value }
 
         values = enum.map { |val|
           case val

--- a/lib/json-schema/util/array_set.rb
+++ b/lib/json-schema/util/array_set.rb
@@ -1,3 +1,5 @@
+require 'set'
+
 # This is a hack that I don't want to ever use anywhere else or repeat EVER, but we need enums to be
 # an Array to pass schema validation. But we also want fast lookup!
 
@@ -5,9 +7,14 @@ class ArraySet < Array
   def include?(obj)
     if !defined? @values
       @values = Set.new
-      self.each { |x| @values << (x.is_a?(Fixnum) ? x.to_f : x) }
+      self.each { |x| @values << convert_to_float_if_fixnum(x) }
     end
-    obj = obj.to_f if obj.is_a?(Fixnum)
-    @values.include?(obj)
+    @values.include?(convert_to_float_if_fixnum(obj))
+  end
+
+  private
+
+  def convert_to_float_if_fixnum(value)
+    value.is_a?(Fixnum) ? value.to_f : value
   end
 end

--- a/lib/json-schema/util/array_set.rb
+++ b/lib/json-schema/util/array_set.rb
@@ -1,14 +1,13 @@
 # This is a hack that I don't want to ever use anywhere else or repeat EVER, but we need enums to be
-# an Array to pass schema validation. But we also want fast lookup! And we can't use sets because of
-# backport support... so...
+# an Array to pass schema validation. But we also want fast lookup!
 
 class ArraySet < Array
-	def include?(obj)
-		# On first invocation create a HASH (yeah, yeah) to act as our set given the array values
-		if !defined? @array_values
-			@array_values = {}
-			self.each {|x| @array_values[x] = 1}
-		end
-		@array_values.has_key? obj
-	end
+  def include?(obj)
+    if !defined? @values
+      @values = Set.new
+      self.each { |x| @values << (x.is_a?(Fixnum) ? x.to_f : x) }
+    end
+    obj = obj.to_f if obj.is_a?(Fixnum)
+    @values.include?(obj)
+  end
 end

--- a/lib/json-schema/validators/hyper-draft1.rb
+++ b/lib/json-schema/validators/hyper-draft1.rb
@@ -1,0 +1,14 @@
+module JSON
+  class Schema
+
+    class HyperDraft1 < Draft1
+      def initialize
+        super
+        @uri = Addressable::URI.parse("http://json-schema.org/draft-01/hyper-schema#")
+      end
+
+      JSON::Validator.register_validator(self.new)
+      JSON::Validator.register_default_validator(self.new)
+    end
+  end
+end

--- a/lib/json-schema/validators/hyper-draft1.rb
+++ b/lib/json-schema/validators/hyper-draft1.rb
@@ -8,7 +8,6 @@ module JSON
       end
 
       JSON::Validator.register_validator(self.new)
-      JSON::Validator.register_default_validator(self.new)
     end
   end
 end

--- a/lib/json-schema/validators/hyper-draft2.rb
+++ b/lib/json-schema/validators/hyper-draft2.rb
@@ -8,7 +8,6 @@ module JSON
       end
 
       JSON::Validator.register_validator(self.new)
-      JSON::Validator.register_default_validator(self.new)
     end
   end
 end

--- a/lib/json-schema/validators/hyper-draft2.rb
+++ b/lib/json-schema/validators/hyper-draft2.rb
@@ -1,0 +1,14 @@
+module JSON
+  class Schema
+
+    class HyperDraft2 < Draft2
+      def initialize
+        super
+        @uri = Addressable::URI.parse("http://json-schema.org/draft-02/hyper-schema#")
+      end
+
+      JSON::Validator.register_validator(self.new)
+      JSON::Validator.register_default_validator(self.new)
+    end
+  end
+end

--- a/lib/json-schema/validators/hyper-draft4.rb
+++ b/lib/json-schema/validators/hyper-draft4.rb
@@ -8,7 +8,6 @@ module JSON
       end
 
       JSON::Validator.register_validator(self.new)
-      JSON::Validator.register_default_validator(self.new)
     end
   end
 end

--- a/test/support/enum_validation.rb
+++ b/test/support/enum_validation.rb
@@ -1,0 +1,76 @@
+module EnumValidation
+  def test_enum
+    schema = {
+      "properties" => {
+        "a" => {"enum" => [1,'boo',[1,2,3],{"a" => "b"}]}
+      }
+    }
+
+    data = { "a" => 1 }
+    assert_valid schema, data
+
+    data["a"] = 'boo'
+    assert_valid schema, data
+
+    data["a"] = [1,2,3]
+    assert_valid schema, data
+
+    data["a"] = {"a" => "b"}
+    assert_valid schema, data
+
+    data["a"] = 'taco'
+    refute_valid schema, data
+
+    data = {}
+    assert_valid schema, data
+  end
+
+  def test_fixed_float_issue_enum
+    schema = {
+      "properties" => {
+        "a" => {
+          "type" => "number",
+          "enum" => [0, 1, 2]
+        }
+      }
+    }
+
+    data = { "a" => 0 }
+    assert_valid schema, data
+
+    data["a"] = 0.0
+    assert_valid schema, data
+
+    data["a"] = 1
+    assert_valid schema, data
+
+    data["a"] = 1.0
+    assert_valid schema, data
+  end
+
+  def test_enum_with_schema_validation
+    schema = {
+      "properties" => {
+        "a" => {"enum" => [1,'boo',[1,2,3],{"a" => "b"}]}
+      }
+    }
+    data = { "a" => 1 }
+    assert_valid(schema, data, :validate_schema => true)
+  end
+
+  module ItemsTests
+    def test_items_single_schema
+      schema = { 'items' => { 'type' => 'string' } }
+
+      assert_valid schema, []
+      assert_valid schema, ['a']
+      assert_valid schema, ['a', 'b']
+
+      refute_valid schema, [1]
+      refute_valid schema, ['a', 1]
+
+      # other types are disregarded
+      assert_valid schema, {'a' => 'foo'}
+    end
+  end
+end

--- a/test/support/enum_validation.rb
+++ b/test/support/enum_validation.rb
@@ -1,5 +1,5 @@
 module EnumValidation
-  def test_enum
+  def test_enum_general
     schema = {
       "properties" => {
         "a" => {"enum" => [1,'boo',[1,2,3],{"a" => "b"}]}
@@ -25,7 +25,7 @@ module EnumValidation
     assert_valid schema, data
   end
 
-  def test_fixed_float_issue_enum
+  def test_enum_number_integer_includes_float
     schema = {
       "properties" => {
         "a" => {
@@ -48,6 +48,54 @@ module EnumValidation
     assert_valid schema, data
   end
 
+  def test_enum_number_float_includes_integer
+    schema = {
+      "properties" => {
+        "a" => {
+          "type" => "number",
+          "enum" => [0.0, 1.0, 2.0]
+        }
+      }
+    }
+
+    data = { "a" => 0.0 }
+    assert_valid schema, data
+
+    data["a"] = 0
+    assert_valid schema, data
+
+
+    data["a"] = 1.0
+    assert_valid schema, data
+
+    data["a"] = 1
+    assert_valid schema, data
+  end
+
+  def test_enum_integer_integer_excludes_float
+    schema = {
+      "properties" => {
+        "a" => {
+          "type" => "integer",
+          "enum" => [0, 1, 2]
+        }
+      }
+    }
+
+    data = { "a" => 0 }
+    assert_valid schema, data
+
+    data["a"] = 0.0
+    refute_valid schema, data
+
+
+    data["a"] = 1
+    assert_valid schema, data
+
+    data["a"] = 1.0
+    refute_valid schema, data
+  end
+
   def test_enum_with_schema_validation
     schema = {
       "properties" => {
@@ -56,21 +104,5 @@ module EnumValidation
     }
     data = { "a" => 1 }
     assert_valid(schema, data, :validate_schema => true)
-  end
-
-  module ItemsTests
-    def test_items_single_schema
-      schema = { 'items' => { 'type' => 'string' } }
-
-      assert_valid schema, []
-      assert_valid schema, ['a']
-      assert_valid schema, ['a', 'b']
-
-      refute_valid schema, [1]
-      refute_valid schema, ['a', 1]
-
-      # other types are disregarded
-      assert_valid schema, {'a' => 'foo'}
-    end
   end
 end

--- a/test/support/enum_validation.rb
+++ b/test/support/enum_validation.rb
@@ -96,7 +96,7 @@ module EnumValidation
       assert_valid schema, data
     end
 
-    def test_enum_integer_integer_excludes_float
+    def test_enum_integer_excludes_float
       schema = {
         "properties" => {
           "a" => {

--- a/test/support/enum_validation.rb
+++ b/test/support/enum_validation.rb
@@ -1,108 +1,133 @@
 module EnumValidation
-  def test_enum_general
-    schema = {
-      "properties" => {
-        "a" => {"enum" => [1,'boo',[1,2,3],{"a" => "b"}]}
-      }
-    }
-
-    data = { "a" => 1 }
-    assert_valid schema, data
-
-    data["a"] = 'boo'
-    assert_valid schema, data
-
-    data["a"] = [1,2,3]
-    assert_valid schema, data
-
-    data["a"] = {"a" => "b"}
-    assert_valid schema, data
-
-    data["a"] = 'taco'
-    refute_valid schema, data
-
-    data = {}
-    assert_valid schema, data
-  end
-
-  def test_enum_number_integer_includes_float
-    schema = {
-      "properties" => {
-        "a" => {
-          "type" => "number",
-          "enum" => [0, 1, 2]
+  module V1_V2
+    def test_enum_optional
+      schema = {
+        "properties" => {
+          "a" => {"enum" => [1,'boo',[1,2,3],{"a" => "b"}], "optional" => true}
         }
       }
-    }
 
-    data = { "a" => 0 }
-    assert_valid schema, data
-
-    data["a"] = 0.0
-    assert_valid schema, data
-
-    data["a"] = 1
-    assert_valid schema, data
-
-    data["a"] = 1.0
-    assert_valid schema, data
+      data = {}
+      assert_valid schema, data
+    end
   end
 
-  def test_enum_number_float_includes_integer
-    schema = {
-      "properties" => {
-        "a" => {
-          "type" => "number",
-          "enum" => [0.0, 1.0, 2.0]
+  module V3_V4
+    def test_enum_optional
+      schema = {
+        "properties" => {
+          "a" => {"enum" => [1,'boo',[1,2,3],{"a" => "b"}]}
         }
       }
-    }
 
-    data = { "a" => 0.0 }
-    assert_valid schema, data
-
-    data["a"] = 0
-    assert_valid schema, data
-
-
-    data["a"] = 1.0
-    assert_valid schema, data
-
-    data["a"] = 1
-    assert_valid schema, data
+      data = {}
+      assert_valid schema, data
+    end
   end
 
-  def test_enum_integer_integer_excludes_float
-    schema = {
-      "properties" => {
-        "a" => {
-          "type" => "integer",
-          "enum" => [0, 1, 2]
+  module General
+    def test_enum_general
+      schema = {
+        "properties" => {
+          "a" => {"enum" => [1,'boo',[1,2,3],{"a" => "b"}]}
         }
       }
-    }
 
-    data = { "a" => 0 }
-    assert_valid schema, data
+      data = { "a" => 1 }
+      assert_valid schema, data
 
-    data["a"] = 0.0
-    refute_valid schema, data
+      data["a"] = 'boo'
+      assert_valid schema, data
 
+      data["a"] = [1,2,3]
+      assert_valid schema, data
 
-    data["a"] = 1
-    assert_valid schema, data
+      data["a"] = {"a" => "b"}
+      assert_valid schema, data
 
-    data["a"] = 1.0
-    refute_valid schema, data
-  end
+      data["a"] = 'taco'
+      refute_valid schema, data
+    end
 
-  def test_enum_with_schema_validation
-    schema = {
-      "properties" => {
-        "a" => {"enum" => [1,'boo',[1,2,3],{"a" => "b"}]}
+    def test_enum_number_integer_includes_float
+      schema = {
+        "properties" => {
+          "a" => {
+            "type" => "number",
+            "enum" => [0, 1, 2]
+          }
+        }
       }
-    }
-    data = { "a" => 1 }
-    assert_valid(schema, data, :validate_schema => true)
+
+      data = { "a" => 0 }
+      assert_valid schema, data
+
+      data["a"] = 0.0
+      assert_valid schema, data
+
+      data["a"] = 1
+      assert_valid schema, data
+
+      data["a"] = 1.0
+      assert_valid schema, data
+    end
+
+    def test_enum_number_float_includes_integer
+      schema = {
+        "properties" => {
+          "a" => {
+            "type" => "number",
+            "enum" => [0.0, 1.0, 2.0]
+          }
+        }
+      }
+
+      data = { "a" => 0.0 }
+      assert_valid schema, data
+
+      data["a"] = 0
+      assert_valid schema, data
+
+
+      data["a"] = 1.0
+      assert_valid schema, data
+
+      data["a"] = 1
+      assert_valid schema, data
+    end
+
+    def test_enum_integer_integer_excludes_float
+      schema = {
+        "properties" => {
+          "a" => {
+            "type" => "integer",
+            "enum" => [0, 1, 2]
+          }
+        }
+      }
+
+      data = { "a" => 0 }
+      assert_valid schema, data
+
+      data["a"] = 0.0
+      refute_valid schema, data
+
+
+      data["a"] = 1
+      assert_valid schema, data
+
+      data["a"] = 1.0
+      refute_valid schema, data
+    end
+
+    def test_enum_with_schema_validation
+      schema = {
+        "properties" => {
+          "a" => {"enum" => [1,'boo',[1,2,3],{"a" => "b"}]}
+        }
+      }
+      data = { "a" => 1 }
+      assert_valid(schema, data, :validate_schema => true)
+    end
   end
 end

--- a/test/test_jsonschema_draft1.rb
+++ b/test/test_jsonschema_draft1.rb
@@ -15,6 +15,8 @@ class JSONSchemaDraft1Test < Minitest::Test
 
   include ArrayValidation::ItemsTests
 
+  include EnumValidation
+
   include NumberValidation::MinMaxTests
 
   include ObjectValidation::AdditionalPropertiesTests

--- a/test/test_jsonschema_draft1.rb
+++ b/test/test_jsonschema_draft1.rb
@@ -15,7 +15,8 @@ class JSONSchemaDraft1Test < Minitest::Test
 
   include ArrayValidation::ItemsTests
 
-  include EnumValidation
+  include EnumValidation::General
+  include EnumValidation::V1_V2
 
   include NumberValidation::MinMaxTests
 
@@ -53,41 +54,6 @@ class JSONSchemaDraft1Test < Minitest::Test
     data = {}
     assert_valid schema, data
   end
-
-  def test_enum
-    # Set up the default datatype
-    schema = {
-      "properties" => {
-        "a" => {"enum" => [1,'boo',[1,2,3],{"a" => "b"}], "optional" => true}
-      }
-    }
-
-    data = {
-      "a" => nil
-    }
-
-    # Make sure all of the above are valid...
-    data["a"] = 1
-    assert_valid schema, data
-
-    data["a"] = 'boo'
-    assert_valid schema, data
-
-    data["a"] = [1,2,3]
-    assert_valid schema, data
-
-    data["a"] = {"a" => "b"}
-    assert_valid schema, data
-
-    # Test something that doesn't exist
-    data["a"] = 'taco'
-    refute_valid schema, data
-
-    # Try it without the key
-    data = {}
-    assert_valid schema, data
-  end
-
 
   def test_max_decimal
     # Set up the default datatype

--- a/test/test_jsonschema_draft2.rb
+++ b/test/test_jsonschema_draft2.rb
@@ -20,7 +20,8 @@ class JSONSchemaDraft2Test < Minitest::Test
   include ArrayValidation::ItemsTests
   include ArrayValidation::UniqueItemsTests
 
-  include EnumValidation
+  include EnumValidation::General
+  include EnumValidation::V1_V2
 
   include NumberValidation::MinMaxTests
   include NumberValidation::MultipleOfTests
@@ -56,40 +57,6 @@ class JSONSchemaDraft2Test < Minitest::Test
       }
     }
 
-    data = {}
-    assert_valid schema, data
-  end
-
-  def test_enum
-    # Set up the default datatype
-    schema = {
-      "properties" => {
-        "a" => {"enum" => [1,'boo',[1,2,3],{"a" => "b"}], "optional" => true}
-      }
-    }
-
-    data = {
-      "a" => nil
-    }
-
-    # Make sure all of the above are valid...
-    data["a"] = 1
-    assert_valid schema, data
-
-    data["a"] = 'boo'
-    assert_valid schema, data
-
-    data["a"] = [1,2,3]
-    assert_valid schema, data
-
-    data["a"] = {"a" => "b"}
-    assert_valid schema, data
-
-    # Test something that doesn't exist
-    data["a"] = 'taco'
-    refute_valid schema, data
-
-    # Try it without the key
     data = {}
     assert_valid schema, data
   end

--- a/test/test_jsonschema_draft2.rb
+++ b/test/test_jsonschema_draft2.rb
@@ -20,6 +20,8 @@ class JSONSchemaDraft2Test < Minitest::Test
   include ArrayValidation::ItemsTests
   include ArrayValidation::UniqueItemsTests
 
+  include EnumValidation
+
   include NumberValidation::MinMaxTests
   include NumberValidation::MultipleOfTests
 

--- a/test/test_jsonschema_draft3.rb
+++ b/test/test_jsonschema_draft3.rb
@@ -22,7 +22,8 @@ class JSONSchemaDraft3Test < Minitest::Test
   include ArrayValidation::AdditionalItemsTests
   include ArrayValidation::UniqueItemsTests
 
-  include EnumValidation
+  include EnumValidation::General
+  include EnumValidation::V3_V4
 
   include NumberValidation::MinMaxTests
   include NumberValidation::MultipleOfTests
@@ -117,39 +118,62 @@ class JSONSchemaDraft3Test < Minitest::Test
     assert(JSON::Validator.validate(schema,data,:strict => true))
   end
 
-  def test_enum
-    # Set up the default datatype
+  def test_strict_properties_additional_props
     schema = {
       "$schema" => "http://json-schema.org/draft-03/schema#",
       "properties" => {
-        "a" => {"enum" => [1,'boo',[1,2,3],{"a" => "b"}]}
-      }
+        "a" => {"type" => "string"},
+        "b" => {"type" => "string"}
+      },
+      "additionalProperties" => {"type" => "integer"}
     }
 
-    data = {
-      "a" => nil
+    data = {"a" => "a"}
+    assert(!JSON::Validator.validate(schema,data,:strict => true))
+
+    data = {"b" => "b"}
+    assert(!JSON::Validator.validate(schema,data,:strict => true))
+
+    data = {"a" => "a", "b" => "b"}
+    assert(JSON::Validator.validate(schema,data,:strict => true))
+
+    data = {"a" => "a", "b" => "b", "c" => "c"}
+    assert(!JSON::Validator.validate(schema,data,:strict => true))
+
+    data = {"a" => "a", "b" => "b", "c" => 3}
+    assert(JSON::Validator.validate(schema,data,:strict => true))
+  end
+
+  def test_strict_properties_pattern_props
+    schema = {
+      "$schema" => "http://json-schema.org/draft-03/schema#",
+      "properties" => {
+        "a" => {"type" => "string"},
+        "b" => {"type" => "string"}
+      },
+      "patternProperties" => {"\\d+ taco" => {"type" => "integer"}}
     }
 
-    # Make sure all of the above are valid...
-    data["a"] = 1
-    assert_valid schema, data
+    data = {"a" => "a"}
+    assert(!JSON::Validator.validate(schema,data,:strict => true))
 
-    data["a"] = 'boo'
-    assert_valid schema, data
+    data = {"b" => "b"}
+    assert(!JSON::Validator.validate(schema,data,:strict => true))
 
-    data["a"] = [1,2,3]
-    assert_valid schema, data
+    data = {"a" => "a", "b" => "b"}
+    assert(JSON::Validator.validate(schema,data,:strict => true))
 
-    data["a"] = {"a" => "b"}
-    assert_valid schema, data
+    data = {"a" => "a", "b" => "b", "c" => "c"}
+    assert(!JSON::Validator.validate(schema,data,:strict => true))
 
-    # Test something that doesn't exist
-    data["a"] = 'taco'
-    refute_valid schema, data
+    data = {"a" => "a", "b" => "b", "c" => 3}
+    assert(!JSON::Validator.validate(schema,data,:strict => true))
 
-    # Try it without the key
-    data = {}
-    assert_valid schema, data
+    data = {"a" => "a", "b" => "b", "23 taco" => 3}
+    assert(JSON::Validator.validate(schema,data,:strict => true))
+
+    data = {"a" => "a", "b" => "b", "23 taco" => "cheese"}
+    assert(!JSON::Validator.validate(schema,data,:strict => true))
   end
 
   def test_disallow

--- a/test/test_jsonschema_draft3.rb
+++ b/test/test_jsonschema_draft3.rb
@@ -22,6 +22,8 @@ class JSONSchemaDraft3Test < Minitest::Test
   include ArrayValidation::AdditionalItemsTests
   include ArrayValidation::UniqueItemsTests
 
+  include EnumValidation
+
   include NumberValidation::MinMaxTests
   include NumberValidation::MultipleOfTests
 

--- a/test/test_jsonschema_draft4.rb
+++ b/test/test_jsonschema_draft4.rb
@@ -22,7 +22,8 @@ class JSONSchemaDraft4Test < Minitest::Test
   include ArrayValidation::AdditionalItemsTests
   include ArrayValidation::UniqueItemsTests
 
-  include EnumValidation
+  include EnumValidation::General
+  include EnumValidation::V3_V4
 
   include NumberValidation::MinMaxTests
   include NumberValidation::MultipleOfTests

--- a/test/test_jsonschema_draft4.rb
+++ b/test/test_jsonschema_draft4.rb
@@ -22,6 +22,8 @@ class JSONSchemaDraft4Test < Minitest::Test
   include ArrayValidation::AdditionalItemsTests
   include ArrayValidation::UniqueItemsTests
 
+  include EnumValidation
+
   include NumberValidation::MinMaxTests
   include NumberValidation::MultipleOfTests
 
@@ -113,6 +115,28 @@ class JSONSchemaDraft4Test < Minitest::Test
 
     # Try it without the key
     data = {}
+    assert_valid schema, data
+  end
+
+  def test_enum
+    # Set up the default datatype
+    schema = {
+      "$schema" => "http://json-schema.org/draft-04/schema#",
+      "properties" => {
+        "a" => {
+          "type" => "number",
+          "enum" => [0, 1, 2]
+        }
+      }
+    }
+
+    data = {
+      "a" => 0
+    }
+
+    assert_valid schema, data
+
+    data["a"] = 0.0
     assert_valid schema, data
   end
 

--- a/test/test_jsonschema_draft4.rb
+++ b/test/test_jsonschema_draft4.rb
@@ -83,78 +83,84 @@ class JSONSchemaDraft4Test < Minitest::Test
     refute_valid schema, {'a' => 1, 'b' => 2, 'c' => 3}
   end
 
-  def test_enum
-    # Set up the default datatype
+  def test_strict_properties
     schema = {
       "$schema" => "http://json-schema.org/draft-04/schema#",
       "properties" => {
-        "a" => {"enum" => [1,'boo',[1,2,3],{"a" => "b"}]}
+        "a" => {"type" => "string"},
+        "b" => {"type" => "string"}
       }
     }
 
-    data = {
-      "a" => nil
-    }
+    data = {"a" => "a"}
+    assert(!JSON::Validator.validate(schema,data,:strict => true))
 
-    # Make sure all of the above are valid...
-    data["a"] = 1
-    assert_valid schema, data
+    data = {"b" => "b"}
+    assert(!JSON::Validator.validate(schema,data,:strict => true))
 
-    data["a"] = 'boo'
-    assert_valid schema, data
+    data = {"a" => "a", "b" => "b"}
+    assert(JSON::Validator.validate(schema,data,:strict => true))
 
-    data["a"] = [1,2,3]
-    assert_valid schema, data
-
-    data["a"] = {"a" => "b"}
-    assert_valid schema, data
-
-    # Test something that doesn't exist
-    data["a"] = 'taco'
-    refute_valid schema, data
-
-    # Try it without the key
-    data = {}
-    assert_valid schema, data
+    data = {"a" => "a", "b" => "b", "c" => "c"}
+    assert(!JSON::Validator.validate(schema,data,:strict => true))
   end
 
-  def test_enum
-    # Set up the default datatype
+  def test_strict_properties_additional_props
     schema = {
       "$schema" => "http://json-schema.org/draft-04/schema#",
       "properties" => {
-        "a" => {
-          "type" => "number",
-          "enum" => [0, 1, 2]
-        }
-      }
+        "a" => {"type" => "string"},
+        "b" => {"type" => "string"}
+      },
+      "additionalProperties" => {"type" => "integer"}
     }
 
-    data = {
-      "a" => 0
-    }
+    data = {"a" => "a"}
+    assert(!JSON::Validator.validate(schema,data,:strict => true))
 
-    assert_valid schema, data
+    data = {"b" => "b"}
+    assert(!JSON::Validator.validate(schema,data,:strict => true))
 
-    data["a"] = 0.0
-    assert_valid schema, data
+    data = {"a" => "a", "b" => "b"}
+    assert(JSON::Validator.validate(schema,data,:strict => true))
+
+    data = {"a" => "a", "b" => "b", "c" => "c"}
+    assert(!JSON::Validator.validate(schema,data,:strict => true))
+
+    data = {"a" => "a", "b" => "b", "c" => 3}
+    assert(JSON::Validator.validate(schema,data,:strict => true))
   end
 
-  def test_enum_with_schema_validation
+  def test_strict_properties_pattern_props
     schema = {
-      "$schema" => "http://json-schema.org/draft-04/schema#",
+      "$schema" => "http://json-schema.org/draft-03/schema#",
       "properties" => {
-        "a" => {"enum" => [1,'boo',[1,2,3],{"a" => "b"}]}
-      }
+        "a" => {"type" => "string"},
+        "b" => {"type" => "string"}
+      },
+      "patternProperties" => {"\\d+ taco" => {"type" => "integer"}}
     }
 
-    data = {
-      "a" => nil
-    }
+    data = {"a" => "a"}
+    assert(!JSON::Validator.validate(schema,data,:strict => true))
 
-    # Make sure all of the above are valid...
-    data["a"] = 1
-    assert(JSON::Validator.validate(schema,data,:validate_schema => true))
+    data = {"b" => "b"}
+    assert(!JSON::Validator.validate(schema,data,:strict => true))
+
+    data = {"a" => "a", "b" => "b"}
+    assert(JSON::Validator.validate(schema,data,:strict => true))
+
+    data = {"a" => "a", "b" => "b", "c" => "c"}
+    assert(!JSON::Validator.validate(schema,data,:strict => true))
+
+    data = {"a" => "a", "b" => "b", "c" => 3}
+    assert(!JSON::Validator.validate(schema,data,:strict => true))
+
+    data = {"a" => "a", "b" => "b", "23 taco" => 3}
+    assert(JSON::Validator.validate(schema,data,:strict => true))
+
+    data = {"a" => "a", "b" => "b", "23 taco" => "cheese"}
+    assert(!JSON::Validator.validate(schema,data,:strict => true))
   end
 
   def test_list_option


### PR DESCRIPTION
I found out that there is a problem with Fixnum und Float values not being treated as equal when checking against an enum list, which they should if the required type is number as it includes all integers.

I don't know why ```include?``` fails here.

And another thing. There are currently two tests failing for draft-1 and draft-2 when they are called with schema validation. The error is: ```JSON::Schema::SchemaError: Schema not found: http://json-schema.org/draft-02/hyper-schema#```
Any quick hints how to fix that? I'm in the office and cannot dig into that right now.