### PR TITLE
Renamed variable in oneOf to avoid name clash

### DIFF
--- a/lib/json-schema/attributes/oneof.rb
+++ b/lib/json-schema/attributes/oneof.rb
@@ -6,7 +6,7 @@ module JSON
       def self.validate(current_schema, data, fragments, processor, validator, options = {})
         errors = Hash.new { |hsh, k| hsh[k] = [] }
 
-        validation_errors = 0
+        validation_error_count = 0
         one_of = current_schema.schema['oneOf']
 
         original_data = data.is_a?(Hash) ? data.clone : data
@@ -27,7 +27,7 @@ module JSON
 
           diff = validation_errors(processor).count - pre_validation_error_count
           valid = false if diff > 0
-          validation_errors += 1 if !valid
+          validation_error_count += 1 if !valid
           while diff > 0
             diff = diff - 1
             errors["oneOf ##{schema_index}"].push(validation_errors(processor).pop)
@@ -37,12 +37,12 @@ module JSON
 
 
 
-        if validation_errors == one_of.length - 1
+        if validation_error_count == one_of.length - 1
           data = success_data
           return
         end
 
-        if validation_errors == one_of.length
+        if validation_error_count == one_of.length
           message = "The property '#{build_fragment(fragments)}' of type #{data.class} did not match any of the required schemas"
         else
           message = "The property '#{build_fragment(fragments)}' of type #{data.class} matched more than one of the required schemas"


### PR DESCRIPTION
I noticed in #216 that we have some bad variable naming. In the OneOf attribute, there's a `validation_errors` instance variable, but the parent (Attribute) class defines a `validation_errors()` method. So in the same file we have both a method and a variable with the same name. This seems to work, but it's confusing and seems like a bad idea.

This renames that variable to `validation_error_count`, to avoid confusion