### PR TITLE
Updated to addressable 2.3.7

### DIFF
--- a/json-schema.gemspec
+++ b/json-schema.gemspec
@@ -24,5 +24,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency "webmock"
   s.add_development_dependency "bundler"
 
-  s.add_runtime_dependency "addressable", '~> 2.3'
+  s.add_runtime_dependency "addressable", '~> 2.3.7'
 end

--- a/lib/json-schema/attributes/formats/uri.rb
+++ b/lib/json-schema/attributes/formats/uri.rb
@@ -7,10 +7,7 @@ module JSON
         return unless data.is_a?(String)
         error_message = "The property '#{build_fragment(fragments)}' must be a valid URI"
         begin
-          # TODO
-          # Addressable only throws an exception on to_s for invalid URI strings, although it
-          # probably should throughout parse already - https://github.com/sporkmonger/addressable/issues/177
-          Addressable::URI.parse(data).to_s
+          Addressable::URI.parse(data)
         rescue Addressable::URI::InvalidURIError
           validation_error(processor, error_message, fragments, current_schema, self, options[:record_errors])
         end


### PR DESCRIPTION
To ensure that invalid uris of the form "::http" throw exceptions rather than failing silently. This aught to make uri parsing more robust

Addressable has finally resolved the bug in https://github.com/ruby-json-schema/json-schema/pull/174 so I suggest we use the fix and hope that it makes uri parsing more robust. I suspect that there should be other changes elsewhere in the code (such as gracefully handling uris in sensitive places).

@RST-J I'd appreciate your feedback on this especially