### PR TITLE
Enabled warnings when running tests

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -14,6 +14,8 @@ end
 
 Rake::TestTask.new do |t|
   t.libs << "."
+  t.warning = true
+  t.verbose = true
   t.test_files = FileList['test/test*.rb']
 end
 

--- a/Rakefile
+++ b/Rakefile
@@ -16,7 +16,9 @@ Rake::TestTask.new do |t|
   t.libs << "."
   t.warning = true
   t.verbose = true
-  t.test_files = FileList['test/test*.rb']
+  t.test_files = FileList.new('test/test*.rb') do |fl|
+    fl.exclude(/test_helper\.rb$/)
+  end
 end
 
 task :test => :update_common_tests

--- a/json-schema.gemspec
+++ b/json-schema.gemspec
@@ -23,5 +23,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency "webmock"
   s.add_development_dependency "bundler"
 
-  s.add_runtime_dependency "addressable", '~> 2.3.7'
+  s.add_runtime_dependency "addressable", '~> 2.3.8'
 end


### PR DESCRIPTION
As mentioned in #219 we want to avoid issues such as redefined methods. Running tests with warnings enabled should help.

Note that this shows up warnings for some existing issues, including some in addressable, so I recommend we merge #226 before this