### PR TITLE
Ignore fragments in schema caching. Fixes #233

### DIFF
--- a/lib/json-schema/validator.rb
+++ b/lib/json-schema/validator.rb
@@ -129,7 +129,7 @@ module JSON
 
     def load_ref_schema(parent_schema, ref)
       schema_uri = absolutize_ref_uri(ref, parent_schema.uri)
-
+      schema_uri.fragment = ''
       return true if self.class.schema_loaded?(schema_uri)
 
       schema = @options[:schema_reader].read(schema_uri)

--- a/test/test_load_ref_schema.rb
+++ b/test/test_load_ref_schema.rb
@@ -1,0 +1,40 @@
+require File.expand_path('../test_helper', __FILE__)
+
+class LoadRefSchemaTests < Minitest::Test
+  def load_other_schema
+    JSON::Validator.add_schema(JSON::Schema.new(
+      {
+        '$schema' => 'http://json-schema.org/draft-04/schema#',
+        'type' => 'object',
+        'properties' => {
+          "title" => {
+            "type" => "string"
+          }
+        }
+      },
+      Addressable::URI.parse("http://example.com/schema#")
+    ))
+  end
+
+  def test_cached_schema
+    schema_url = "http://example.com/schema#"
+    schema = {
+      "$ref" => schema_url
+    }
+    data = {}
+    load_other_schema
+    validator = JSON::Validator.new(schema, data)
+    assert JSON::Validator.schema_loaded?(schema_url)
+  end
+
+  def test_cached_schema_with_fragment
+    schema_url = "http://example.com/schema#"
+    schema = {
+      "$ref" => "#{schema_url}/properties/title"
+    }
+    data = {}
+    load_other_schema
+    validator = JSON::Validator.new(schema, data)
+    assert JSON::Validator.schema_loaded?(schema_url)
+  end
+end


### PR DESCRIPTION
If the URIs used in a `$ref` are absolute, but include fragments, then the fragment is not removed when the validator searches its cache to see what schemas are loaded, leading to duplication of schemas in the cache.

This code & test fixes that issue.