### PR TITLE
Only rescue errors explicitly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Change Log
+All notable changes to this project will be documented in this file.
+Please keep to the changelog format described on [keepachangelog.com](http://keepachangelog.com).
+This project adheres to [Semantic Versioning](http://semver.org/).
+
+## [Unreleased]
+### Added
+- Added a changelog
+
+### Changed
+- Made validation failures raise a `JSON::Schema::SchemaParseError` and data
+  loading failures a `JSON::Schema::JsonLoadError`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,6 @@ The Ruby JSON Schema library is meant to be a community effort, and as such, the
 
 All individuals that have a pull request merged will receive collaborator access to the repository. Due to the restrictions on RubyGems authentication, permissions to release a gem must be requested along with the email desired to be associated with the release credentials.
 
-Accepting changes to the JSON Schema library shall be made through the use of pull requests on GitHub. A pull request must receive at least two (2) "+1" comments from current contributors to the JSON Schema library before being accepted and merged. If a breaking issue and fix exists, please feel free to contact the project maintainer at hoxworth@gmail.com or @hoxworth for faster resolution.
+Accepting changes to the JSON Schema library shall be made through the use of pull requests on GitHub. A pull request must receive at least two (2) "+1" comments from current contributors, and include a relevant changelog entry, before being accepted and merged. If a breaking issue and fix exists, please feel free to contact the project maintainer at hoxworth@gmail.com or @hoxworth for faster resolution.
 
 Releases follow semantic versioning and may be made at a maintainer's discretion.

--- a/lib/json-schema/attributes/formats/date.rb
+++ b/lib/json-schema/attributes/formats/date.rb
@@ -11,7 +11,8 @@ module JSON
           if REGEXP.match(data)
             begin
               Date.parse(data)
-            rescue Exception
+            rescue ArgumentError => e
+              raise e unless e.message == 'invalid date'
               validation_error(processor, error_message, fragments, current_schema, self, options[:record_errors])
             end
           else

--- a/lib/json-schema/attributes/formats/date_time.rb
+++ b/lib/json-schema/attributes/formats/date_time.rb
@@ -14,18 +14,16 @@ module JSON
 
             begin
               Date.parse(parts[0])
-            rescue Exception
+            rescue ArgumentError => e
+              raise e unless e.message == 'invalid date'
               validation_error(processor, error_message, fragments, current_schema, self, options[:record_errors])
               return
             end
 
-            begin
-              validation_error(processor, error_message, fragments, current_schema, self, options[:record_errors]) and return if m[1].to_i > 23
-              validation_error(processor, error_message, fragments, current_schema, self, options[:record_errors]) and return if m[2].to_i > 59
-              validation_error(processor, error_message, fragments, current_schema, self, options[:record_errors]) and return if m[3].to_i > 59
-            rescue Exception
-              validation_error(processor, error_message, fragments, current_schema, self, options[:record_errors])
-            end
+            validation_error(processor, error_message, fragments, current_schema, self, options[:record_errors]) and return if m.length < 4
+            validation_error(processor, error_message, fragments, current_schema, self, options[:record_errors]) and return if m[1].to_i > 23
+            validation_error(processor, error_message, fragments, current_schema, self, options[:record_errors]) and return if m[2].to_i > 59
+            validation_error(processor, error_message, fragments, current_schema, self, options[:record_errors]) and return if m[3].to_i > 59
           else
             validation_error(processor, error_message, fragments, current_schema, self, options[:record_errors])
           end

--- a/lib/json-schema/attributes/not.rb
+++ b/lib/json-schema/attributes/not.rb
@@ -17,7 +17,7 @@ module JSON
             message = "The property '#{build_fragment(fragments)}' of type #{data.class} matched the disallowed schema"
             failed = false
           end
-        rescue
+        rescue ValidationError
           # Yay, we failed validation.
         end
 

--- a/lib/json-schema/errors/json_load_error.rb
+++ b/lib/json-schema/errors/json_load_error.rb
@@ -1,0 +1,6 @@
+module JSON
+  class Schema
+    class JsonLoadError < StandardError
+    end
+  end
+end

--- a/lib/json-schema/errors/schema_parse_error.rb
+++ b/lib/json-schema/errors/schema_parse_error.rb
@@ -1,0 +1,8 @@
+require 'json/common'
+
+module JSON
+  class Schema
+    class SchemaParseError < JSON::ParserError
+    end
+  end
+end

--- a/lib/json-schema/schema/reader.rb
+++ b/lib/json-schema/schema/reader.rb
@@ -57,8 +57,8 @@ module JSON
       # @param location [#to_s] The location from which to read the schema
       # @return [JSON::Schema]
       # @raise [JSON::Schema::ReadRefused] if +accept_uri+ or +accept_file+
-      #   indicated the schema should not be readed
-      # @raise [JSON::ParserError] if the schema was not a valid JSON object
+      #   indicated the schema could not be read
+      # @raise [JSON::Schema::ParseError] if the schema was not a valid JSON object
       def read(location)
         uri  = Addressable::URI.parse(location.to_s)
         body = if uri.scheme.nil? || uri.scheme == 'file'

--- a/lib/json-schema/util/uri.rb
+++ b/lib/json-schema/util/uri.rb
@@ -1,6 +1,8 @@
 module JSON
   module Util
     module URI
+      SUPPORTED_PROTOCOLS = %w(http https ftp tftp sftp ssh svn+ssh telnet nntp gopher wais ldap prospero)
+
       def self.normalized_uri(uri)
         uri = Addressable::URI.parse(uri) unless uri.is_a?(Addressable::URI)
         # Check for absolute path

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -34,14 +34,4 @@ class Minitest::Test
     errors = JSON::Validator.fully_validate(schema, data, options)
     refute_equal([], errors, "#{data.inspect} should be invalid for schema:\n#{schema.inspect}")
   end
-
-  def parser_error
-    if defined?(::Yajl)
-      Yajl::ParseError
-    elsif defined?(::MultiJson)
-      MultiJson::ParseError
-    else
-      JSON::ParserError
-    end
-  end
 end

--- a/test/test_initialize_data.rb
+++ b/test/test_initialize_data.rb
@@ -10,11 +10,11 @@ class InitializeDataTest < Minitest::Test
 
     assert(JSON::Validator.validate(schema, data, :parse_data => false))
 
-    assert_raises(parser_error) do
+    assert_raises(JSON::Schema::JsonParseError) do
       JSON::Validator.validate(schema, data, :json => true)
     end
 
-    assert_raises(Errno::ENOENT) { JSON::Validator.validate(schema, data, :uri => true) }
+    assert_raises(JSON::Schema::JsonLoadError) { JSON::Validator.validate(schema, data, :uri => true) }
   end
 
   def test_parse_integer_string
@@ -27,7 +27,7 @@ class InitializeDataTest < Minitest::Test
 
     assert(JSON::Validator.validate(schema, data, :json => true))
 
-    assert_raises(Errno::ENOENT) { JSON::Validator.validate(schema, data, :uri => true) }
+    assert_raises(JSON::Schema::JsonLoadError) { JSON::Validator.validate(schema, data, :uri => true) }
   end
 
   def test_parse_hash_string
@@ -40,7 +40,7 @@ class InitializeDataTest < Minitest::Test
 
     assert(JSON::Validator.validate(schema, data, :json => true))
 
-    assert_raises(Errno::ENOENT) { JSON::Validator.validate(schema, data, :uri => true) }
+    assert_raises(JSON::Schema::JsonLoadError) { JSON::Validator.validate(schema, data, :uri => true) }
   end
 
   def test_parse_json_string
@@ -53,7 +53,7 @@ class InitializeDataTest < Minitest::Test
 
     assert(JSON::Validator.validate(schema, data, :json => true))
 
-    assert_raises(Errno::ENOENT) { JSON::Validator.validate(schema, data, :uri => true) }
+    assert_raises(JSON::Schema::JsonLoadError) { JSON::Validator.validate(schema, data, :uri => true) }
   end
 
   def test_parse_valid_uri_string
@@ -66,7 +66,7 @@ class InitializeDataTest < Minitest::Test
 
     assert(JSON::Validator.validate(schema, data, :parse_data => false))
 
-    assert_raises(parser_error) do
+    assert_raises(JSON::Schema::JsonParseError) do
       JSON::Validator.validate(schema, data, :json => true)
     end
 
@@ -83,11 +83,17 @@ class InitializeDataTest < Minitest::Test
 
     assert(JSON::Validator.validate(schema, data, :parse_data => false))
 
-    assert_raises(parser_error) do
+    stub_request(:get, "foo.bar").to_return(:status => [500, "Internal Server Error"])
+
+    assert(JSON::Validator.validate(schema, data))
+
+    assert(JSON::Validator.validate(schema, data, :parse_data => false))
+
+    assert_raises(JSON::Schema::JsonParseError) do
       JSON::Validator.validate(schema, data, :json => true)
     end
 
-    assert_raises(Timeout::Error) { JSON::Validator.validate(schema, data, :uri => true) }
+    assert_raises(JSON::Schema::JsonLoadError) { JSON::Validator.validate(schema, data, :uri => true) }
   end
 
   def test_parse_integer

--- a/test/test_schema_loader.rb
+++ b/test/test_schema_loader.rb
@@ -67,7 +67,7 @@ class TestSchemaReader < Minitest::Test
 
     reader = JSON::Schema::Reader.new
 
-    assert_raises(parser_error) do
+    assert_raises(JSON::Schema::JsonParseError) do
       reader.read(ADDRESS_SCHEMA_URI)
     end
   end


### PR DESCRIPTION
Only rescue errors explicitly

There are a lot of places in the code where we rescue any error, at all.
That's quite dangerous, as it could conceal bugs.

I've changed it so that we always specify which error class we want to
catch. Mostly it's been a minor change, but there are two API changes:

* When it comes to loading data I've had to introduce an explicit list
  of protocols which we can load json over (otherwise it's possible to
  have a uri with a scheme that makes no sense - it'd still be a valid
  uri but loading from it is impossible). I've used the list of
  protocols that addressable recognizes for now.
* No matter what JSON parser you use, we now always raise a
  JSON::Schema::JsonParseError. Without doing this it would be tricky to
  handle parser errors identically, for all parsers (the other option
  would be to catch a long list of potential parse errors, but this
  seems more sensible).
