### PR TITLE
Explicitly notes :strict overrides any required properties set in schema

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -82,7 +82,7 @@ JSON::Validator.validate('user.json', data, :list => true)
 
 h3. Strictly validate an object's properties
 
-With the <code>:strict</code> option, validation fails when an object contains properties that are not defined in the schema's property list or doesn't match the <code>additionalProperties</code> property. Furthermore, all properties are treated as <code>required</code> by default.
+With the <code>:strict</code> option, validation fails when an object contains properties that are not defined in the schema's property list or doesn't match the <code>additionalProperties</code> property. Furthermore, all properties are treated as <code>required</code> regardless of <code>required</code> properties set in the schema.
 
 <pre>
 require 'rubygems'


### PR DESCRIPTION
This tiny change in the readme just makes it clear that strict mode overrides the `required` properties set in the schema. The text said all properties were `required by default`, which I assumed meant that they would be required unless the schema explicitly specified otherwise. A very small but potentially frustrating distinction.

If others are like me this could save them some time debugging their complex schema & fragments. 