### PR TITLE
Speed up JSON::Validator.validate

### DIFF
--- a/lib/json-schema/attributes/formats/uri.rb
+++ b/lib/json-schema/attributes/formats/uri.rb
@@ -7,7 +7,7 @@ module JSON
         return unless data.is_a?(String)
         error_message = "The property '#{build_fragment(fragments)}' must be a valid URI"
         begin
-          Addressable::URI.parse(data)
+          JSON::Util::URI.parse(data)
         rescue Addressable::URI::InvalidURIError
           validation_error(processor, error_message, fragments, current_schema, self, options[:record_errors])
         end

--- a/lib/json-schema/schema.rb
+++ b/lib/json-schema/schema.rb
@@ -11,7 +11,7 @@ module JSON
 
       # If there is an ID on this schema, use it to generate the URI
       if @schema['id'] && @schema['id'].kind_of?(String)
-        temp_uri = JSON::Util::URI.parse(@schema['id'])
+        temp_uri = Addressable::URI.parse(@schema['id'])
         if temp_uri.relative?
           temp_uri = uri.join(temp_uri)
         end

--- a/lib/json-schema/schema.rb
+++ b/lib/json-schema/schema.rb
@@ -11,7 +11,7 @@ module JSON
 
       # If there is an ID on this schema, use it to generate the URI
       if @schema['id'] && @schema['id'].kind_of?(String)
-        temp_uri = Addressable::URI.parse(@schema['id'])
+        temp_uri = JSON::Util::URI.parse(@schema['id'])
         if temp_uri.relative?
           temp_uri = uri.join(temp_uri)
         end

--- a/lib/json-schema/schema.rb
+++ b/lib/json-schema/schema.rb
@@ -17,7 +17,8 @@ module JSON
         end
         @uri = temp_uri
       end
-      @uri.fragment = ''
+      # @@TODO maybe this whole modified uri should be cached for performance too
+      @uri.fragment = '' if !@uri.fragment.nil? && !@uri.fragment.empty?
 
       # If there is a $schema on this schema, use it to determine which validator to use
       if @schema['$schema']

--- a/lib/json-schema/schema/reader.rb
+++ b/lib/json-schema/schema/reader.rb
@@ -60,7 +60,7 @@ module JSON
       #   indicated the schema should not be readed
       # @raise [JSON::ParserError] if the schema was not a valid JSON object
       def read(location)
-        uri  = Addressable::URI.parse(location.to_s)
+        uri  = JSON::Util::URI.parse(location.to_s)
         body = if uri.scheme.nil? || uri.scheme == 'file'
                  uri = Addressable::URI.convert_path(uri.path)
                  read_file(Pathname.new(uri.path).expand_path)

--- a/lib/json-schema/util/uri.rb
+++ b/lib/json-schema/util/uri.rb
@@ -4,10 +4,10 @@ module JSON
   module Util
     class URI
       include Singleton
-      attr_accessor :parse_cache, :normalized_cache
+      attr_accessor :cache
 
       def normalized_uri(uri)
-        uri = self.class.parse(uri) unless uri.is_a?(Addressable::URI)
+        uri = Addressable::URI.parse(uri) unless uri.is_a?(Addressable::URI)
         # Check for absolute path
         if uri.relative?
           data = uri.to_s
@@ -17,17 +17,12 @@ module JSON
         uri
       end
 
-      # These caches create a race condition in multithreaded environments
+      # This cache creates a race condition in multithreaded environments
       # This is OK because the worst case result of the race is
       # a cache miss
-      def self.parse(uri)
-        instance.parse_cache ||= {}
-        instance.parse_cache[uri.to_s.freeze] ||= Addressable::URI.parse(uri)
-      end
-
       def self.normalized_uri(uri)
-        instance.normalized_cache ||= {}
-        instance.normalized_cache[uri.to_s.freeze] ||= instance.normalized_uri(uri)
+        instance.cache ||= {}
+        instance.cache[uri] ||= instance.normalized_uri(uri)
       end
     end
   end

--- a/lib/json-schema/util/uri.rb
+++ b/lib/json-schema/util/uri.rb
@@ -17,6 +17,9 @@ module JSON
         uri
       end
 
+      # This cache creates a race condition in multithreaded environments
+      # This is OK because the worst case result of the race is
+      # a cache miss
       def self.normalized_uri(uri)
         instance.cache ||= {}
         instance.cache[uri] ||= instance.normalized_uri(uri)

--- a/lib/json-schema/util/uri.rb
+++ b/lib/json-schema/util/uri.rb
@@ -11,7 +11,7 @@ module JSON
         # Check for absolute path
         if uri.relative?
           data = uri.to_s
-          data = "#{Dir.pwd}/#{data}" if data[0,1] != '/'
+          data = "#{Dir.pwd}/#{data}" if data[0, 1] != '/'
           uri = Addressable::URI.convert_path(data)
         end
         uri
@@ -22,7 +22,7 @@ module JSON
       # a cache miss
       def self.normalized_uri(uri)
         instance.normalize_cache ||= {}
-        instance.normalize_cache[uri] ||= instance.normalized_uri(uri)
+        instance.normalize_cache[uri.to_s] ||= instance.normalized_uri(uri)
       end
 
       def self.parse(uri)

--- a/lib/json-schema/util/uri.rb
+++ b/lib/json-schema/util/uri.rb
@@ -4,7 +4,7 @@ module JSON
   module Util
     class URI
       include Singleton
-      attr_accessor :cache
+      attr_accessor :normalize_cache, :parse_cache
 
       def normalized_uri(uri)
         uri = Addressable::URI.parse(uri) unless uri.is_a?(Addressable::URI)
@@ -21,8 +21,13 @@ module JSON
       # This is OK because the worst case result of the race is
       # a cache miss
       def self.normalized_uri(uri)
-        instance.cache ||= {}
-        instance.cache[uri] ||= instance.normalized_uri(uri)
+        instance.normalize_cache ||= {}
+        instance.normalize_cache[uri] ||= instance.normalized_uri(uri)
+      end
+
+      def self.parse(uri)
+        instance.parse_cache ||= {}
+        instance.parse_cache[uri.to_s] ||= Addressable::URI.parse(uri)
       end
     end
   end

--- a/lib/json-schema/util/uri.rb
+++ b/lib/json-schema/util/uri.rb
@@ -1,7 +1,12 @@
+require 'singleton'
+
 module JSON
   module Util
-    module URI
-      def self.normalized_uri(uri)
+    class URI
+      include Singleton
+      attr_accessor :cache
+
+      def normalized_uri(uri)
         uri = Addressable::URI.parse(uri) unless uri.is_a?(Addressable::URI)
         # Check for absolute path
         if uri.relative?
@@ -10,6 +15,11 @@ module JSON
           uri = Addressable::URI.convert_path(data)
         end
         uri
+      end
+
+      def self.normalized_uri(uri)
+        instance.cache ||= {}
+        instance.cache[uri] ||= instance.normalized_uri(uri)
       end
     end
   end

--- a/lib/json-schema/validator.rb
+++ b/lib/json-schema/validator.rb
@@ -474,6 +474,8 @@ module JSON
 
         if @@json_backend == 'yajl'
           @@serializer = lambda{|o| Yajl::Encoder.encode(o) }
+        elsif @@json_backend == 'json'
+          @@serializer = lambda{|o| JSON.dump(o) }
         else
           @@serializer = lambda{|o| YAML.dump(o) }
         end

--- a/lib/json-schema/validator.rb
+++ b/lib/json-schema/validator.rb
@@ -138,15 +138,15 @@ module JSON
     end
 
     def absolutize_ref_uri(ref, parent_schema_uri)
-      ref_uri = Addressable::URI.parse(ref)
-      ref_uri.fragment = ''
+      ref_uri = JSON::Util::URI.parse(ref)
+      ref_uri.fragment = '' if !ref_uri.fragment.nil? && !ref_uri.fragment.empty?
 
       return ref_uri if ref_uri.absolute?
       # This is a self reference and thus the schema does not need to be re-loaded
       return parent_schema_uri if ref_uri.path.empty?
 
       uri = parent_schema_uri.clone
-      uri.fragment = ''
+      uri.fragment = '' if !uri.fragment.nil? && !uri.fragment.empty?
       Util::URI.normalized_uri(uri.join(ref_uri.path))
     end
 
@@ -344,7 +344,7 @@ module JSON
 
       def validator_for_uri(schema_uri)
         return default_validator unless schema_uri
-        u = Addressable::URI.parse(schema_uri)
+        u = JSON::Util::URI.parse(schema_uri)
         validator = validators["#{u.scheme}://#{u.host}#{u.path}"]
         if validator.nil?
           raise JSON::Schema::SchemaError.new("Schema not found: #{schema_uri}")
@@ -517,7 +517,7 @@ module JSON
       if schema.is_a?(String)
         begin
           # Build a fake URI for this
-          schema_uri = Addressable::URI.parse(fake_uuid(schema))
+          schema_uri = JSON::Util::URI.parse(fake_uuid(schema))
           schema = JSON::Schema.new(JSON::Validator.parse(schema), schema_uri, @options[:version])
           if @options[:list] && @options[:fragment].nil?
             schema = schema.to_array_schema
@@ -539,14 +539,14 @@ module JSON
             schema = self.class.schema_for_uri(schema_uri)
             if @options[:list] && @options[:fragment].nil?
               schema = schema.to_array_schema
-              schema.uri = Addressable::URI.parse(fake_uuid(schema.hash.to_s))
+              schema.uri = JSON::Util::URI.parse(fake_uuid(schema.hash.to_s))
               Validator.add_schema(schema)
             end
             schema
           end
         end
       elsif schema.is_a?(Hash)
-        schema_uri = Addressable::URI.parse(fake_uuid(schema.hash.to_s))
+        schema_uri = JSON::Util::URI.parse(fake_uuid(schema.hash.to_s))
         schema = JSON::Schema.stringify(schema)
         schema = JSON::Schema.new(schema, schema_uri, @options[:version])
         if @options[:list] && @options[:fragment].nil?

--- a/lib/json-schema/validator.rb
+++ b/lib/json-schema/validator.rb
@@ -138,7 +138,7 @@ module JSON
     end
 
     def absolutize_ref_uri(ref, parent_schema_uri)
-      ref_uri = JSON::Util::URI.parse(ref)
+      ref_uri = Addressable::URI.parse(ref)
       ref_uri.fragment = ''
 
       return ref_uri if ref_uri.absolute?
@@ -344,7 +344,7 @@ module JSON
 
       def validator_for_uri(schema_uri)
         return default_validator unless schema_uri
-        u = JSON::Util::URI.parse(schema_uri)
+        u = Addressable::URI.parse(schema_uri)
         validator = validators["#{u.scheme}://#{u.host}#{u.path}"]
         if validator.nil?
           raise JSON::Schema::SchemaError.new("Schema not found: #{schema_uri}")
@@ -517,7 +517,7 @@ module JSON
       if schema.is_a?(String)
         begin
           # Build a fake URI for this
-          schema_uri = JSON::Util::URI.parse(fake_uuid(schema))
+          schema_uri = Addressable::URI.parse(fake_uuid(schema))
           schema = JSON::Schema.new(JSON::Validator.parse(schema), schema_uri, @options[:version])
           if @options[:list] && @options[:fragment].nil?
             schema = schema.to_array_schema
@@ -539,14 +539,14 @@ module JSON
             schema = self.class.schema_for_uri(schema_uri)
             if @options[:list] && @options[:fragment].nil?
               schema = schema.to_array_schema
-              schema.uri = JSON::Util::URI.parse(fake_uuid(schema.hash.to_s))
+              schema.uri = Addressable::URI.parse(fake_uuid(schema.hash.to_s))
               Validator.add_schema(schema)
             end
             schema
           end
         end
       elsif schema.is_a?(Hash)
-        schema_uri = JSON::Util::URI.parse(fake_uuid(schema.hash.to_s))
+        schema_uri = Addressable::URI.parse(fake_uuid(schema.hash.to_s))
         schema = JSON::Schema.stringify(schema)
         schema = JSON::Schema.new(schema, schema_uri, @options[:version])
         if @options[:list] && @options[:fragment].nil?

--- a/lib/json-schema/validator.rb
+++ b/lib/json-schema/validator.rb
@@ -539,14 +539,14 @@ module JSON
             schema = self.class.schema_for_uri(schema_uri)
             if @options[:list] && @options[:fragment].nil?
               schema = schema.to_array_schema
-              schema.uri = Addressable::URI.parse(fake_uuid(serialize(schema.schema)))
+              schema.uri = Addressable::URI.parse(fake_uuid(schema.hash.to_s))
               Validator.add_schema(schema)
             end
             schema
           end
         end
       elsif schema.is_a?(Hash)
-        schema_uri = Addressable::URI.parse(fake_uuid(serialize(schema)))
+        schema_uri = Addressable::URI.parse(fake_uuid(schema.hash.to_s))
         schema = JSON::Schema.stringify(schema)
         schema = JSON::Schema.new(schema, schema_uri, @options[:version])
         if @options[:list] && @options[:fragment].nil?

--- a/lib/json-schema/validator.rb
+++ b/lib/json-schema/validator.rb
@@ -138,7 +138,7 @@ module JSON
     end
 
     def absolutize_ref_uri(ref, parent_schema_uri)
-      ref_uri = Addressable::URI.parse(ref)
+      ref_uri = JSON::Util::URI.parse(ref)
       ref_uri.fragment = ''
 
       return ref_uri if ref_uri.absolute?
@@ -344,7 +344,7 @@ module JSON
 
       def validator_for_uri(schema_uri)
         return default_validator unless schema_uri
-        u = Addressable::URI.parse(schema_uri)
+        u = JSON::Util::URI.parse(schema_uri)
         validator = validators["#{u.scheme}://#{u.host}#{u.path}"]
         if validator.nil?
           raise JSON::Schema::SchemaError.new("Schema not found: #{schema_uri}")
@@ -517,7 +517,7 @@ module JSON
       if schema.is_a?(String)
         begin
           # Build a fake URI for this
-          schema_uri = Addressable::URI.parse(fake_uuid(schema))
+          schema_uri = JSON::Util::URI.parse(fake_uuid(schema))
           schema = JSON::Schema.new(JSON::Validator.parse(schema), schema_uri, @options[:version])
           if @options[:list] && @options[:fragment].nil?
             schema = schema.to_array_schema
@@ -539,14 +539,14 @@ module JSON
             schema = self.class.schema_for_uri(schema_uri)
             if @options[:list] && @options[:fragment].nil?
               schema = schema.to_array_schema
-              schema.uri = Addressable::URI.parse(fake_uuid(schema.hash.to_s))
+              schema.uri = JSON::Util::URI.parse(fake_uuid(schema.hash.to_s))
               Validator.add_schema(schema)
             end
             schema
           end
         end
       elsif schema.is_a?(Hash)
-        schema_uri = Addressable::URI.parse(fake_uuid(schema.hash.to_s))
+        schema_uri = JSON::Util::URI.parse(fake_uuid(schema.hash.to_s))
         schema = JSON::Schema.stringify(schema)
         schema = JSON::Schema.new(schema, schema_uri, @options[:version])
         if @options[:list] && @options[:fragment].nil?


### PR DESCRIPTION
Addressible's URI parsing shows up at the top of the profiler for our use case on JRuby, as well as YAML dumping.

This patch
1. adds a cache to ```JSON::Util::URI.normalized_uri```
2. adds a cache for ```Addressable::URI.parse``` in ```JSON::Util::URI.parse```
3. prevents clearing an already cleared URI fragment in JSON::Schema#initialize
4. uses Hash#hash for calculating uuids instead of serializing the hash.

There are many further gains to be had still, especially if we can find a way to remove the mutex around initializing a schema, as that is proving to be terrible for performance on JRuby in a multi-threaded environment.

I'm pretty much finished with this pass - almost 8x is a pretty nice gain.

benchmark: https://github.com/mjc/json-schema-perf

MRI 2.2.2 results: **2.89x faster from file, 5.55x faster from hash.**

JRuby 1.7.20 results: **2.38x faster from file, 7.86x faster from hash.**

#### MRI 2.2.2 before
```
Calculating -------------------------------------
json-schema from file
                       181.000  i/100ms
json-schema from hash
                        87.000  i/100ms
-------------------------------------------------
json-schema from file
                          1.962k (± 6.3%) i/s -     58.644k
json-schema from hash
                        938.211  (± 6.2%) i/s -     28.101k

Comparison:
json-schema from file:     1961.8 i/s
json-schema from hash:      938.2 i/s - 2.09x slower
```

#### MRI 2.2.2 after
```
json-schema from file
                          5.668k (± 7.4%) i/s -    169.162k
json-schema from hash
                          5.210k (± 7.1%) i/s -    155.696k


Comparison:
json-schema from file:     5668.0 i/s
json-schema from hash:     5210.2 i/s - 1.09x slower
```
#### JRuby 1.7.20 before
```
Calculating -------------------------------------
json-schema from file
                       200.000  i/100ms
json-schema from hash
                       138.000  i/100ms
-------------------------------------------------
json-schema from file
                          2.075k (± 6.1%) i/s -     62.000k
json-schema from hash
                          1.401k (± 5.4%) i/s -     41.952k

Comparison:
json-schema from file:     2074.9 i/s
json-schema from hash:     1401.0 i/s - 1.48x slower
```

#### JRuby 1.7.20 after
```
Calculating -------------------------------------
json-schema from file
                       474.000  i/100ms
json-schema from hash
                         1.002k i/100ms
-------------------------------------------------
json-schema from file
                          4.942k (± 5.7%) i/s -    147.888k
json-schema from hash
                         10.773k (± 6.5%) i/s -    322.644k

Comparison:
json-schema from hash:    10773.1 i/s
json-schema from file:     4942.2 i/s - 2.18x slower
```
