### PR TITLE
Added type casting for limiting min/max

### DIFF
--- a/lib/json-schema/attributes/limit.rb
+++ b/lib/json-schema/attributes/limit.rb
@@ -15,7 +15,7 @@ module JSON
 
       def self.invalid?(schema, data)
         exclusive = exclusive?(schema)
-        limit = limit(schema)
+        limit = limit(schema).to_i
 
         if limit_name.start_with?('max')
           exclusive ? data >= limit : data > limit


### PR DESCRIPTION
Both 0 and "0" are valid json integers when representing min/max.
I added a cast to the limit to ensure proper comparison.