### PR TITLE
Developers often use Pathname objects for paths

### DIFF
--- a/lib/json-schema/validator.rb
+++ b/lib/json-schema/validator.rb
@@ -512,7 +512,7 @@ module JSON
     end
 
     def initialize_schema(schema)
-      if schema.is_a?(String)
+      if schema.is_a?(String) || schema.is_a?(Pathname)
         begin
           # Build a fake URI for this
           schema_uri = Addressable::URI.parse(fake_uuid(schema))


### PR DESCRIPTION
Strings are naive path names, and in Ruby we have an object specifically for path names called Pathname.