### PR TITLE
Added the orderedhash gem for ruby 1.8 builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,5 +22,7 @@ matrix:
       gemfile: "gemfiles/Gemfile.yajl-ruby.x"
     - rvm: "2.2"
       gemfile: "gemfiles/Gemfile.uuidtools.x"
-  allow_failures:
     - rvm: "1.8"
+      gemfile: "gemfiles/Gemfile.ruby_18.x"
+  exclude:
+     - rvm: "1.8"

--- a/gemfiles/Gemfile.ruby_18.x
+++ b/gemfiles/Gemfile.ruby_18.x
@@ -1,0 +1,6 @@
+source "https://rubygems.org"
+
+gemspec :path => "../"
+
+gem "json"
+gem "orderedhash"


### PR DESCRIPTION
This should allow the 1.8 build to pass reliably as it makes hash keys
ordered, and many of the tests rely on hash keys appearing in creation
order.