### PR TITLE
Redux: speed up JSON::Validator.validate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,5 +8,6 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Added a changelog
 
 ### Changed
+- Improved performance by caching the parsing and normalization of URIs
 - Made validation failures raise a `JSON::Schema::SchemaParseError` and data
   loading failures a `JSON::Schema::JsonLoadError`

--- a/lib/json-schema/attributes/formats/uri.rb
+++ b/lib/json-schema/attributes/formats/uri.rb
@@ -7,7 +7,7 @@ module JSON
         return unless data.is_a?(String)
         error_message = "The property '#{build_fragment(fragments)}' must be a valid URI"
         begin
-          Addressable::URI.parse(data)
+          JSON::Util::URI.parse(data)
         rescue Addressable::URI::InvalidURIError
           validation_error(processor, error_message, fragments, current_schema, self, options[:record_errors])
         end

--- a/lib/json-schema/attributes/formats/uri.rb
+++ b/lib/json-schema/attributes/formats/uri.rb
@@ -1,5 +1,6 @@
 require 'json-schema/attribute'
-require 'addressable/uri'
+require 'json-schema/errors/uri_error'
+
 module JSON
   class Schema
     class UriFormat < FormatAttribute
@@ -8,7 +9,7 @@ module JSON
         error_message = "The property '#{build_fragment(fragments)}' must be a valid URI"
         begin
           JSON::Util::URI.parse(data)
-        rescue Addressable::URI::InvalidURIError
+        rescue JSON::Schema::UriError
           validation_error(processor, error_message, fragments, current_schema, self, options[:record_errors])
         end
       end

--- a/lib/json-schema/attributes/ref.rb
+++ b/lib/json-schema/attributes/ref.rb
@@ -52,7 +52,7 @@ module JSON
           fragment_path = ''
           fragments.each do |fragment|
             if fragment && fragment != ''
-              fragment = Addressable::URI.unescape(fragment.gsub('~0', '~').gsub('~1', '/'))
+              fragment = JSON::Util::URI.unescaped_uri(fragment.gsub('~0', '~').gsub('~1', '/'))
               if target_schema.is_a?(Array)
                 target_schema = target_schema[fragment.to_i]
               else

--- a/lib/json-schema/attributes/ref.rb
+++ b/lib/json-schema/attributes/ref.rb
@@ -1,5 +1,6 @@
 require 'json-schema/attribute'
 require 'json-schema/errors/schema_error'
+require 'json-schema/util/uri'
 
 module JSON
   class Schema
@@ -21,21 +22,23 @@ module JSON
       def self.get_referenced_uri_and_schema(s, current_schema, validator)
         uri,schema = nil,nil
 
-        temp_uri = Addressable::URI.parse(s['$ref'])
-        if temp_uri.relative?
-          temp_uri = current_schema.uri.clone
-          # Check for absolute path
-          path = s['$ref'].split("#")[0]
-          if path.nil? || path == ''
-            temp_uri.path = current_schema.uri.path
-          elsif path[0,1] == "/"
-            temp_uri.path = Pathname.new(path).cleanpath.to_s
-          else
-            temp_uri = current_schema.uri.join(path)
+        temp_uri = JSON::Util::URI.parse(s['$ref'])
+        temp_uri.defer_validation do
+          if temp_uri.relative?
+            temp_uri.merge!(current_schema.uri)
+            # Check for absolute path
+            path, fragment = s['$ref'].split("#")
+            if path.nil? || path == ''
+              temp_uri.path = current_schema.uri.path
+            elsif path[0,1] == "/"
+              temp_uri.path = Pathname.new(path).cleanpath.to_s
+            else
+              temp_uri.join!(path)
+            end
+            temp_uri.fragment = fragment
           end
-          temp_uri.fragment = s['$ref'].split("#")[1]
+          temp_uri.fragment = "" if temp_uri.fragment.nil? || temp_uri.fragment.empty?
         end
-        temp_uri.fragment = "" if temp_uri.fragment.nil?
 
         # Grab the parent schema from the schema list
         schema_key = temp_uri.to_s.split("#")[0] + "#"

--- a/lib/json-schema/errors/uri_error.rb
+++ b/lib/json-schema/errors/uri_error.rb
@@ -1,0 +1,6 @@
+module JSON
+  class Schema
+    class UriError < StandardError
+    end
+  end
+end

--- a/lib/json-schema/schema.rb
+++ b/lib/json-schema/schema.rb
@@ -17,7 +17,7 @@ module JSON
         end
         @uri = temp_uri
       end
-      @uri.fragment = ''
+      @uri = JSON::Util::URI.strip_fragment(@uri)
 
       # If there is a $schema on this schema, use it to determine which validator to use
       if @schema['$schema']

--- a/lib/json-schema/schema.rb
+++ b/lib/json-schema/schema.rb
@@ -11,7 +11,7 @@ module JSON
 
       # If there is an ID on this schema, use it to generate the URI
       if @schema['id'] && @schema['id'].kind_of?(String)
-        temp_uri = Addressable::URI.parse(@schema['id'])
+        temp_uri = JSON::Util::URI.parse(@schema['id'])
         if temp_uri.relative?
           temp_uri = uri.join(temp_uri)
         end
@@ -60,4 +60,3 @@ module JSON
     end
   end
 end
-

--- a/lib/json-schema/schema/reader.rb
+++ b/lib/json-schema/schema/reader.rb
@@ -60,7 +60,7 @@ module JSON
       #   indicated the schema could not be read
       # @raise [JSON::Schema::ParseError] if the schema was not a valid JSON object
       def read(location)
-        uri  = Addressable::URI.parse(location.to_s)
+        uri  = JSON::Util::URI.parse(location.to_s)
         body = if uri.scheme.nil? || uri.scheme == 'file'
                  uri = Addressable::URI.convert_path(uri.path)
                  read_file(Pathname.new(uri.path).expand_path)

--- a/lib/json-schema/schema/reader.rb
+++ b/lib/json-schema/schema/reader.rb
@@ -1,5 +1,4 @@
 require 'open-uri'
-require 'addressable/uri'
 require 'pathname'
 
 module JSON
@@ -62,7 +61,7 @@ module JSON
       def read(location)
         uri  = JSON::Util::URI.parse(location.to_s)
         body = if uri.scheme.nil? || uri.scheme == 'file'
-                 uri = Addressable::URI.convert_path(uri.path)
+                 uri = JSON::Util::URI.file_uri(uri)
                  read_file(Pathname.new(uri.path).expand_path)
                else
                  read_uri(uri)
@@ -103,7 +102,7 @@ module JSON
 
       def read_file(pathname)
         if accept_file?(pathname)
-          File.read(Addressable::URI.unescape(pathname.to_s))
+          File.read(JSON::Util::URI.unescaped_uri(pathname.to_s))
         else
           raise JSON::Schema::ReadRefused.new(pathname.to_s, :file)
         end

--- a/lib/json-schema/util/uri.rb
+++ b/lib/json-schema/util/uri.rb
@@ -36,10 +36,11 @@ module JSON
       end
 
       def self.strip_fragment(uri)
-        if uri.fragment.nil? || uri.fragment.empty?
-          uri
+        parsed_uri = parse(uri)
+        if parsed_uri.fragment.nil? || parsed_uri.fragment.empty?
+          parsed_uri
         else
-          uri.merge(:fragment => "")
+          parsed_uri.merge(:fragment => "")
         end
       end
     end

--- a/lib/json-schema/util/uri.rb
+++ b/lib/json-schema/util/uri.rb
@@ -3,15 +3,44 @@ module JSON
     module URI
       SUPPORTED_PROTOCOLS = %w(http https ftp tftp sftp ssh svn+ssh telnet nntp gopher wais ldap prospero)
 
-      def self.normalized_uri(uri)
-        uri = Addressable::URI.parse(uri) unless uri.is_a?(Addressable::URI)
-        # Check for absolute path
-        if uri.relative?
-          data = uri.to_s
-          data = "#{Dir.pwd}/#{data}" if data[0,1] != '/'
-          uri = Addressable::URI.convert_path(data)
+      def self.normalized_uri(uri, base_path = Dir.pwd)
+        @normalize_cache ||= {}
+        normalized_uri = @normalize_cache[uri]
+
+        if !normalized_uri
+          normalized_uri = parse(uri)
+          # Check for absolute path
+          if normalized_uri.relative?
+            data = normalized_uri
+            data = File.join(base_path, data) if data.path[0,1] != "/"
+            normalized_uri = Addressable::URI.convert_path(data)
+          end
+          @normalize_cache[uri] = normalized_uri.freeze
         end
-        uri
+
+        normalized_uri
+      end
+
+      def self.parse(uri)
+        if uri.is_a?(Addressable::URI)
+          return uri.dup
+        else
+          @parse_cache ||= {}
+          parsed_uri = @parse_cache[uri]
+          if parsed_uri
+            parsed_uri.dup
+          else
+            @parse_cache[uri] = Addressable::URI.parse(uri)
+          end
+        end
+      end
+
+      def self.strip_fragment(uri)
+        if uri.fragment.nil? || uri.fragment.empty?
+          uri
+        else
+          uri.merge(:fragment => "")
+        end
       end
     end
   end

--- a/lib/json-schema/validator.rb
+++ b/lib/json-schema/validator.rb
@@ -484,6 +484,8 @@ module JSON
 
         if @@json_backend == 'yajl'
           @@serializer = lambda{|o| Yajl::Encoder.encode(o) }
+        elsif @@json_backend == 'json'
+          @@serializer = lambda{|o| JSON.dump(o) }
         else
           @@serializer = lambda{|o| YAML.dump(o) }
         end

--- a/lib/json-schema/validator.rb
+++ b/lib/json-schema/validator.rb
@@ -1,4 +1,3 @@
-require 'addressable/uri'
 require 'open-uri'
 require 'pathname'
 require 'bigdecimal'
@@ -609,7 +608,7 @@ module JSON
         end
       else
         begin
-          File.read(Addressable::URI.unescape(uri.path))
+          File.read(JSON::Util::URI.unescaped_uri(uri))
         rescue SystemCallError => e
           raise JSON::Schema::JsonLoadError, e.message
         end

--- a/lib/json-schema/validator.rb
+++ b/lib/json-schema/validator.rb
@@ -137,8 +137,7 @@ module JSON
     end
 
     def absolutize_ref_uri(ref, parent_schema_uri)
-      ref_uri = JSON::Util::URI.parse(ref)
-      ref_uri.fragment = ''
+      ref_uri = JSON::Util::URI.strip_fragment(ref)
 
       return ref_uri if ref_uri.absolute?
       # This is a self reference and thus the schema does not need to be re-loaded

--- a/lib/json-schema/validators/draft1.rb
+++ b/lib/json-schema/validators/draft1.rb
@@ -2,7 +2,7 @@ require 'json-schema/schema/validator'
 
 module JSON
   class Schema
-    
+
     class Draft1 < Validator
       def initialize
         super
@@ -33,13 +33,13 @@ module JSON
           'uri' => UriFormat
         }
         @formats = @default_formats.clone
-        @uri = Addressable::URI.parse("http://json-schema.org/draft-01/schema#")
+        @uri = JSON::Util::URI.parse("http://json-schema.org/draft-01/schema#")
         @names = ["draft1"]
         @metaschema_name = "draft-01.json"
       end
-      
+
       JSON::Validator.register_validator(self.new)
     end
-    
+
   end
 end

--- a/lib/json-schema/validators/draft2.rb
+++ b/lib/json-schema/validators/draft2.rb
@@ -2,7 +2,7 @@ require 'json-schema/schema/validator'
 
 module JSON
   class Schema
-    
+
     class Draft2 < Validator
       def initialize
         super
@@ -34,13 +34,13 @@ module JSON
           'uri' => UriFormat
         }
         @formats = @default_formats.clone
-        @uri = Addressable::URI.parse("http://json-schema.org/draft-02/schema#")
+        @uri = JSON::Util::URI.parse("http://json-schema.org/draft-02/schema#")
         @names = ["draft2"]
         @metaschema_name = "draft-02.json"
       end
-      
+
       JSON::Validator.register_validator(self.new)
     end
-    
+
   end
 end

--- a/lib/json-schema/validators/draft3.rb
+++ b/lib/json-schema/validators/draft3.rb
@@ -2,7 +2,7 @@ require 'json-schema/schema/validator'
 
 module JSON
   class Schema
-    
+
     class Draft3 < Validator
       def initialize
         super
@@ -38,13 +38,13 @@ module JSON
           'uri' => UriFormat
         }
         @formats = @default_formats.clone
-        @uri = Addressable::URI.parse("http://json-schema.org/draft-03/schema#")
+        @uri = JSON::Util::URI.parse("http://json-schema.org/draft-03/schema#")
         @names = ["draft3", "http://json-schema.org/draft-03/schema#"]
         @metaschema_name = "draft-03.json"
       end
-      
+
       JSON::Validator.register_validator(self.new)
     end
-    
+
   end
 end

--- a/lib/json-schema/validators/draft4.rb
+++ b/lib/json-schema/validators/draft4.rb
@@ -43,7 +43,7 @@ module JSON
           'uri' => UriFormat
         }
         @formats = @default_formats.clone
-        @uri = Addressable::URI.parse("http://json-schema.org/draft-04/schema#")
+        @uri = JSON::Util::URI.parse("http://json-schema.org/draft-04/schema#")
         @names = ["draft4", "http://json-schema.org/draft-04/schema#"]
         @metaschema_name = "draft-04.json"
       end

--- a/lib/json-schema/validators/hyper-draft1.rb
+++ b/lib/json-schema/validators/hyper-draft1.rb
@@ -4,7 +4,7 @@ module JSON
     class HyperDraft1 < Draft1
       def initialize
         super
-        @uri = Addressable::URI.parse("http://json-schema.org/draft-01/hyper-schema#")
+        @uri = JSON::Util::URI.parse("http://json-schema.org/draft-01/hyper-schema#")
       end
 
       JSON::Validator.register_validator(self.new)

--- a/lib/json-schema/validators/hyper-draft2.rb
+++ b/lib/json-schema/validators/hyper-draft2.rb
@@ -4,7 +4,7 @@ module JSON
     class HyperDraft2 < Draft2
       def initialize
         super
-        @uri = Addressable::URI.parse("http://json-schema.org/draft-02/hyper-schema#")
+        @uri = JSON::Util::URI.parse("http://json-schema.org/draft-02/hyper-schema#")
       end
 
       JSON::Validator.register_validator(self.new)

--- a/lib/json-schema/validators/hyper-draft4.rb
+++ b/lib/json-schema/validators/hyper-draft4.rb
@@ -4,7 +4,7 @@ module JSON
     class HyperDraft4 < Draft4
       def initialize
         super
-        @uri = Addressable::URI.parse("http://json-schema.org/draft-04/hyper-schema#")
+        @uri = JSON::Util::URI.parse("http://json-schema.org/draft-04/hyper-schema#")
       end
 
       JSON::Validator.register_validator(self.new)


### PR DESCRIPTION
This is a rebase and update of #255 

I've pulled out the change to the way uuids are calculated (in #255 the uuid of a Hash is calculated by taking a SHA of `Hash.hash`, whereas in the original the SHA of the string of the hash is used) because I feel that the risk is high and a better solution would be to use a faster hashing algorithm.

However, I've expanded the use of caching to get around the speed problems in Addressable.

Worst case this should be faster than the current implementation.