### PR TITLE
Made sure we include the module name for SchemaParseErrors

### DIFF
--- a/lib/json-schema/validator.rb
+++ b/lib/json-schema/validator.rb
@@ -569,7 +569,7 @@ module JSON
         end
         Validator.add_schema(schema)
       else
-        raise SchemaParseError, "Invalid schema - must be either a string or a hash"
+        raise JSON::Schema::SchemaParseError, "Invalid schema - must be either a string or a hash"
       end
 
       schema

--- a/test/test_ruby_schema.rb
+++ b/test/test_ruby_schema.rb
@@ -56,4 +56,10 @@ class RubySchemaTest < Minitest::Test
 
     assert_valid schema, data, :validate_schema => true
   end
+
+  def test_schema_of_unrecognized_type
+    assert_raises JSON::Schema::SchemaParseError do
+      JSON::Validator.validate(Object.new, {})
+    end
+  end
 end


### PR DESCRIPTION
If you pass an unrecognized object for the schema, we should be raising a SchemaParseError, however instead right now a NameError is raised, beacuse we're not correctly qualifying the error class with it's module.

I've corrected the class/module name and added tests.

This fixes #292