### PR TITLE
new feature :require_all

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -84,7 +84,8 @@ h3. Strictly validate an object's properties
 
 With the <code>:strict</code> option, validation fails when an object contains properties that are not defined in the schema's property list or doesn't match the <code>additionalProperties</code> property.
 
-With the <code>:require_all</code> option, all properties are treated as <code>required</code> regardless of <code>required</code> properties set in the schema.
+With the <code>:require_all</code> option, all properties are treated as <code>required</code> regardless of <code>required</code> properties set in the schema. The default is <code>true</code> when <code>:strict</code> is true,
+unless <code>:require_all</code> is explicitly set.
 
 <pre>
 require 'rubygems'
@@ -98,10 +99,10 @@ schema = {
   }
 }
 
-JSON::Validator.validate(schema, {"a" => 1, "b" => 2}, :strict => true)            # ==> true
-JSON::Validator.validate(schema, {"a" => 1, "b" => 2, "c" => 3}, :strict => true)  # ==> false
-JSON::Validator.validate(schema, {"a" => 1}, :strict => true)                      # ==> true
-JSON::Validator.validate(schema, {"a" => 1}, :require_all => true)                 # ==> false
+JSON::Validator.validate(schema, {"a" => 1, "b" => 2}, :strict => true)              # ==> true
+JSON::Validator.validate(schema, {"a" => 1, "b" => 2, "c" => 3}, :strict => true)    # ==> false
+JSON::Validator.validate(schema, {"a" => 1}, :strict => true)                        # ==> false
+JSON::Validator.validate(schema, {"a" => 1}, :strict => true, :require_all => false) # ==> true
 </pre>
 
 h3. Catch a validation error and print it out

--- a/README.textile
+++ b/README.textile
@@ -82,7 +82,9 @@ JSON::Validator.validate('user.json', data, :list => true)
 
 h3. Strictly validate an object's properties
 
-With the <code>:strict</code> option, validation fails when an object contains properties that are not defined in the schema's property list or doesn't match the <code>additionalProperties</code> property. Furthermore, all properties are treated as <code>required</code> regardless of <code>required</code> properties set in the schema.
+With the <code>:strict</code> option, validation fails when an object contains properties that are not defined in the schema's property list or doesn't match the <code>additionalProperties</code> property.
+
+With the <code>:require_all</code> option, all properties are treated as <code>required</code> regardless of <code>required</code> properties set in the schema.
 
 <pre>
 require 'rubygems'
@@ -98,7 +100,8 @@ schema = {
 
 JSON::Validator.validate(schema, {"a" => 1, "b" => 2}, :strict => true)            # ==> true
 JSON::Validator.validate(schema, {"a" => 1, "b" => 2, "c" => 3}, :strict => true)  # ==> false
-JSON::Validator.validate(schema, {"a" => 1}, :strict => true)                      # ==> false
+JSON::Validator.validate(schema, {"a" => 1}, :strict => true)                      # ==> true
+JSON::Validator.validate(schema, {"a" => 1}, :require_all => true)                 # ==> false
 </pre>
 
 h3. Catch a validation error and print it out

--- a/lib/json-schema/attributes/properties.rb
+++ b/lib/json-schema/attributes/properties.rb
@@ -4,7 +4,7 @@ module JSON
   class Schema
     class PropertiesAttribute < Attribute
       def self.required?(schema, options)
-        schema.fetch('required') { options[:strict] }
+        schema.fetch('required') { options[:require_all] }
       end
 
       def self.validate(current_schema, data, fragments, processor, validator, options = {})

--- a/lib/json-schema/attributes/properties.rb
+++ b/lib/json-schema/attributes/properties.rb
@@ -4,6 +4,7 @@ module JSON
   class Schema
     class PropertiesAttribute < Attribute
       def self.required?(schema, options)
+        fail "required?"
         schema.fetch('required') { options[:require_all] }
       end
 

--- a/lib/json-schema/attributes/properties.rb
+++ b/lib/json-schema/attributes/properties.rb
@@ -4,7 +4,6 @@ module JSON
   class Schema
     class PropertiesAttribute < Attribute
       def self.required?(schema, options)
-        fail "required?"
         schema.fetch('required') { options[:require_all] }
       end
 
@@ -68,7 +67,7 @@ module JSON
       # draft4 relies on its own RequiredAttribute validation at a higher level, rather than
       # as an attribute of individual properties.
       def self.required?(schema, options)
-        options[:strict] == true
+        options[:require_all] == true
       end
     end
   end

--- a/lib/json-schema/validator.rb
+++ b/lib/json-schema/validator.rb
@@ -28,6 +28,7 @@ module JSON
       :insert_defaults => false,
       :clear_cache => true,
       :strict => false,
+      :require_all => false,
       :parse_data => true
     }
     @@validators = {}
@@ -48,6 +49,7 @@ module JSON
       @validation_options = @options[:record_errors] ? {:record_errors => true} : {}
       @validation_options[:insert_defaults] = true if @options[:insert_defaults]
       @validation_options[:strict] = true if @options[:strict] == true
+      @validation_options[:require_all] = true if @options[:require_all] == true
       @validation_options[:clear_cache] = false if @options[:clear_cache] == false
 
       @@mutex.synchronize { @base_schema = initialize_schema(schema_data) }

--- a/lib/json-schema/validator.rb
+++ b/lib/json-schema/validator.rb
@@ -49,7 +49,9 @@ module JSON
       @validation_options = @options[:record_errors] ? {:record_errors => true} : {}
       @validation_options[:insert_defaults] = true if @options[:insert_defaults]
       @validation_options[:strict] = true if @options[:strict] == true
-      @validation_options[:require_all] = true if @options[:require_all] == true
+      if @validation_options[:strict] == true && opts[:require_all] != false
+        @validation_options[:require_all] = true
+      end
       @validation_options[:clear_cache] = false if @options[:clear_cache] == false
 
       @@mutex.synchronize { @base_schema = initialize_schema(schema_data) }

--- a/test/support/strict_validation.rb
+++ b/test/support/strict_validation.rb
@@ -19,6 +19,9 @@ module StrictValidation
 
     data = {"a" => "a", "b" => "b", "c" => "c"}
     assert(!JSON::Validator.validate(schema,data,:strict => true))
+
+    data = {"b" => "b"}
+    assert(JSON::Validator.validate(schema,data,:strict => true,:require_all => false))
   end
 
   def test_strict_error_message


### PR DESCRIPTION
This PR makes the `:strict` validation feature, optionally, a little less strict.

If the `:require_all` option flag is set explicitly to `false` and `strict:true`, then the current strict behavior of requiring all properties be present is turned off, and the schema definition of `required` is preferred.

This allows for testing `additionalProperties` schema feature in isolation.
