### PR TITLE
Addressable gem dependency fix

### DIFF
--- a/json-schema.gemspec
+++ b/json-schema.gemspec
@@ -23,5 +23,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency "webmock"
   s.add_development_dependency "bundler"
 
-  s.add_runtime_dependency "addressable", '~> 2.3'
+  s.add_runtime_dependency "addressable", '>= 2.3'
 end

--- a/json-schema.gemspec
+++ b/json-schema.gemspec
@@ -23,5 +23,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency "webmock"
   s.add_development_dependency "bundler"
 
-  s.add_runtime_dependency "addressable", '~> 2.3.8'
+  s.add_runtime_dependency "addressable", '~> 2.3'
 end


### PR DESCRIPTION
A new version of addressable gem is out (2.4.x). Without this fix, json-schema will not work with the latest version of the addressable gem.