### PR TITLE
Allow addressable 2.4+ to work with json-schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - Made all `validate*` methods on `JSON::Validator` ultimately call `validate!`
+- Updated addressable dependency to 2.4.0
 
 ## [2.6.2] - 2016-05-13
 

--- a/Rakefile
+++ b/Rakefile
@@ -14,7 +14,8 @@ end
 
 Rake::TestTask.new do |t|
   t.libs << "."
-  t.warning = true
+  # disabled warnings because addressable 2.4 has lots of them
+  # t.warning = true
   t.verbose = true
   t.test_files = FileList.new('test/*_test.rb')
 end

--- a/json-schema.gemspec
+++ b/json-schema.gemspec
@@ -23,5 +23,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency "webmock"
   s.add_development_dependency "bundler"
 
-  s.add_runtime_dependency "addressable", '~> 2.3.8'
+  s.add_runtime_dependency "addressable", '>= 2.4'
 end

--- a/test/initialize_data_test.rb
+++ b/test/initialize_data_test.rb
@@ -40,7 +40,7 @@ class InitializeDataTest < Minitest::Test
 
     assert(JSON::Validator.validate(schema, data, :json => true))
 
-    assert_raises(JSON::Schema::JsonLoadError) { JSON::Validator.validate(schema, data, :uri => true) }
+    assert_raises(JSON::Schema::UriError) { JSON::Validator.validate(schema, data, :uri => true) }
   end
 
   def test_parse_json_string


### PR DESCRIPTION
I've had to change one of the specs because of this. It seems that
addressable now raises an error if you parse a uri that looks like a
json text, which was one of our test cases.

This fixes and supersedes #301