### PR TITLE
Attach URI to Read Error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+# Changed
+- Attached failed `uri` or `pathname`  to read errors for more meaning
+
 ## [2.6.1] - 2016-02-26
 
 ### Fixed

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -32,3 +32,4 @@ CONTRIBUTORS
 * Ben Kirzhner - @benkirzhner
 * RST-J - @RST-J
 * Christian Treppo - @treppo
+* Benjamin Falk - @benfalk

--- a/lib/json-schema/schema/reader.rb
+++ b/lib/json-schema/schema/reader.rb
@@ -3,9 +3,8 @@ require 'pathname'
 
 module JSON
   class Schema
-    # Raised by {JSON::Schema::Reader} when one of its settings indicate
-    # a schema should not be readed.
-    class ReadRefused < StandardError
+    # Base for any reading exceptions encountered by {JSON::Schema::Reader}
+    class ReadError < StandardError
       # @return [String] the requested schema location which was refused
       attr_reader :location
 
@@ -15,7 +14,34 @@ module JSON
       def initialize(location, type)
         @location = location
         @type = type
-        super("Read of #{type == :uri ? 'URI' : type} at #{location} refused!")
+        super(error_message)
+      end
+
+      private
+
+      def error_message
+        "Read error for #{type_string} at #{location}!"
+      end
+
+      def type_string
+        type == :uri ? 'URI' : type.to_s
+      end
+    end
+
+    # Raised by {JSON::Schema::Reader} when one of its settings indicate
+    # a schema should not be readed.
+    class ReadRefused < ReadError
+      private
+      def error_message
+        "Read of #{type_string} at #{location} refused!"
+      end
+    end
+
+    # Raised by {JSON::Schema::Reader} when an attempt to read a schema fails
+    class ReadFailed < ReadError
+      private
+      def error_message
+        "Read of #{type_string} at #{location} failed!"
       end
     end
 
@@ -58,6 +84,7 @@ module JSON
       # @raise [JSON::Schema::ReadRefused] if +accept_uri+ or +accept_file+
       #   indicated the schema could not be read
       # @raise [JSON::Schema::ParseError] if the schema was not a valid JSON object
+      # @raise [JSON::Schema::ReadFailed] if read fails
       def read(location)
         uri  = JSON::Util::URI.parse(location.to_s)
         body = if uri.scheme.nil? || uri.scheme == 'file'
@@ -98,6 +125,8 @@ module JSON
         else
           raise JSON::Schema::ReadRefused.new(uri.to_s, :uri)
         end
+      rescue OpenURI::HTTPError, SocketError
+        raise JSON::Schema::ReadFailed.new(uri.to_s, :uri)
       end
 
       def read_file(pathname)
@@ -106,6 +135,8 @@ module JSON
         else
           raise JSON::Schema::ReadRefused.new(pathname.to_s, :file)
         end
+      rescue Errno::ENOENT
+        raise JSON::Schema::ReadFailed.new(pathname.to_s, :file)
       end
     end
   end

--- a/test/test_bad_schema_ref.rb
+++ b/test/test_bad_schema_ref.rb
@@ -19,7 +19,7 @@ class BadSchemaRefTest < Minitest::Test
     }
 
     data = [1,2,3]
-    assert_raises(Errno::ENOENT) do
+    assert_raises(JSON::Schema::ReadFailed) do
       JSON::Validator.validate(schema,data)
     end
   end
@@ -32,7 +32,7 @@ class BadSchemaRefTest < Minitest::Test
     }
 
     data = [1,2,3]
-    assert_raises(SocketError, OpenURI::HTTPError) do
+    assert_raises(JSON::Schema::ReadFailed) do
       JSON::Validator.validate(schema,data)
     end
   end


### PR DESCRIPTION
When getting a `404` or `500` error it was impossible to know which
file was causing the problem with a schema that had many external
references.  This attaches the uri that failed to the error if it's
an OpenURI error, which makes is easy to know what refrenced file
was the culprit.