### PR TITLE
Reformatted the examples to make them easier to read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+- Reformatted examples in the readme
+
 ## [2.6.1] - 2016-02-26
 
 ### Fixed


### PR DESCRIPTION
There are a large number of examples in the readme. I find them really hard to read and learn from.

In this PR I've gone through all the examples in the readme, checked that the examples work, and reorganised them into two sections:

1. Basic usage
2. Optional flags

Both sections are working code examples.