### PR TITLE
Made it possible to have refs that include URI-special characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+- Made it possible to include colons in a $ref
+
 ### Changed
 - Reformatted examples in the readme
 

--- a/lib/json-schema/attributes/ref.rb
+++ b/lib/json-schema/attributes/ref.rb
@@ -48,11 +48,11 @@ module JSON
         if ref_schema
           # Perform fragment resolution to retrieve the appropriate level for the schema
           target_schema = ref_schema.schema
-          fragments = temp_uri.fragment.split("/")
+          fragments = JSON::Util::URI.parse(JSON::Util::URI.unescape_uri(temp_uri)).fragment.split("/")
           fragment_path = ''
           fragments.each do |fragment|
             if fragment && fragment != ''
-              fragment = JSON::Util::URI.unescaped_uri(fragment.gsub('~0', '~').gsub('~1', '/'))
+              fragment = fragment.gsub('~0', '~').gsub('~1', '/')
               if target_schema.is_a?(Array)
                 target_schema = target_schema[fragment.to_i]
               else

--- a/lib/json-schema/schema/reader.rb
+++ b/lib/json-schema/schema/reader.rb
@@ -102,7 +102,7 @@ module JSON
 
       def read_file(pathname)
         if accept_file?(pathname)
-          File.read(JSON::Util::URI.unescaped_uri(pathname.to_s))
+          File.read(JSON::Util::URI.unescaped_path(pathname.to_s))
         else
           raise JSON::Schema::ReadRefused.new(pathname.to_s, :file)
         end

--- a/lib/json-schema/util/uri.rb
+++ b/lib/json-schema/util/uri.rb
@@ -54,7 +54,11 @@ module JSON
         Addressable::URI.convert_path(parsed_uri.path)
       end
 
-      def self.unescaped_uri(uri)
+      def self.unescape_uri(uri)
+        Addressable::URI.unescape(uri)
+      end
+
+      def self.unescaped_path(uri)
         parsed_uri = parse(uri)
 
         Addressable::URI.unescape(parsed_uri.path)

--- a/lib/json-schema/validator.rb
+++ b/lib/json-schema/validator.rb
@@ -608,7 +608,7 @@ module JSON
         end
       else
         begin
-          File.read(JSON::Util::URI.unescaped_uri(uri))
+          File.read(JSON::Util::URI.unescaped_path(uri))
         rescue SystemCallError => e
           raise JSON::Schema::JsonLoadError, e.message
         end

--- a/test/schemas/definition_schema_with_special_characters.json
+++ b/test/schemas/definition_schema_with_special_characters.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "properties": {
+    "a": {
+      "$ref": "#/definitions/foo:bar"
+    }
+  },
+  "definitions": {
+    "foo:bar": {
+      "type": "integer"
+    }
+  }
+}

--- a/test/test_definition.rb
+++ b/test/test_definition.rb
@@ -6,6 +6,10 @@ class RelativeDefinitionTest < Minitest::Test
     assert_valid schema_fixture_path('definition_schema.json'), {"a" => 5}
   end
 
+  def test_definition_schema_with_special_characters
+    assert_valid schema_fixture_path('definition_schema_with_special_characters.json'), {"a" => 5}
+  end
+
   def test_relative_definition
     schema = schema_fixture_path('relative_definition_schema.json')
     assert_valid schema, {"a" => 5}


### PR DESCRIPTION
Turns out that before:

* if you had a ref that included a colon, the text before the colon was
  treated as the scheme and the text after the colon as a path
* the unescape_uri method was actually only parsing the path of the
  uri (therefore anything before a colon was being stripped when passed
  to unescape_uri)

Fixes #319