### PR TITLE
Stopped the additional properties test from using class_eval

### DIFF
--- a/test/support/test_helper.rb
+++ b/test/support/test_helper.rb
@@ -27,14 +27,14 @@ class Minitest::Test
     File.join(File.dirname(__FILE__), '../data', filename)
   end
 
-  def assert_valid(schema, data, options = {})
+  def assert_valid(schema, data, options = {}, msg = "#{data.inspect} should be valid for schema:\n#{schema.inspect}")
     errors = validation_errors(schema, data, options)
-    assert_equal([], errors, "#{data.inspect} should be valid for schema:\n#{schema.inspect}")
+    assert_equal([], errors, msg)
   end
 
-  def refute_valid(schema, data, options = {})
+  def refute_valid(schema, data, options = {}, msg = "#{data.inspect} should be invalid for schema:\n#{schema.inspect}")
     errors = validation_errors(schema, data, options)
-    refute_equal([], errors, "#{data.inspect} should be invalid for schema:\n#{schema.inspect}")
+    refute_equal([], errors, msg)
   end
 
   def validation_errors(schema, data, options)


### PR DESCRIPTION
`class_eval` is dangerous to use, as it injects a string into a class as
ruby code, meaning that it's very easy to make mistakes. In this case
there is no need to use it, and I have re-written this test to use
multiple assertions per test instead (also not ideal, but better).

I've also made this test use the same assertion helpers as every other
test (previously it was defining it's own assertion helpers).