### PR TITLE
Fixed issues with caching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+- Made sure we really do clear the cache when instructed to
+
 ### Changed
 - Made all `validate*` methods on `JSON::Validator` ultimately call `validate!`
 

--- a/README.md
+++ b/README.md
@@ -256,6 +256,24 @@ begin
 rescue TypeError => e
   e.message
 end
+
+#
+# with the `:clear_cache` option set to true, the internal cache of schemas is
+# cleared after validation (otherwise schemas are cached for efficiency)
+#
+
+File.write("schema.json", v2_schema.to_json)
+
+# => true
+JSON::Validator.validate("schema.json", {})
+
+File.write("schema.json", schema.to_json)
+
+# => true
+JSON::Validator.validate("schema.json", {}, :clear_cache => true)
+
+# => false
+JSON::Validator.validate("schema.json", {})
 ```
 
 Extending Schemas

--- a/lib/json-schema/validator.rb
+++ b/lib/json-schema/validator.rb
@@ -18,7 +18,7 @@ module JSON
   class Validator
 
     @@schemas = {}
-    @@cache_schemas = false
+    @@cache_schemas = true
     @@default_opts = {
       :list => false,
       :version => nil,
@@ -48,7 +48,7 @@ module JSON
       @validation_options = @options[:record_errors] ? {:record_errors => true} : {}
       @validation_options[:insert_defaults] = true if @options[:insert_defaults]
       @validation_options[:strict] = true if @options[:strict] == true
-      @validation_options[:clear_cache] = true if @@cache_schemas || @options[:clear_cache]
+      @validation_options[:clear_cache] = true if !@@cache_schemas || @options[:clear_cache]
 
       @@mutex.synchronize { @base_schema = initialize_schema(schema_data) }
       @original_data = data

--- a/lib/json-schema/validator.rb
+++ b/lib/json-schema/validator.rb
@@ -26,7 +26,7 @@ module JSON
       :record_errors => false,
       :errors_as_objects => false,
       :insert_defaults => false,
-      :clear_cache => true,
+      :clear_cache => false,
       :strict => false,
       :parse_data => true
     }
@@ -48,7 +48,7 @@ module JSON
       @validation_options = @options[:record_errors] ? {:record_errors => true} : {}
       @validation_options[:insert_defaults] = true if @options[:insert_defaults]
       @validation_options[:strict] = true if @options[:strict] == true
-      @validation_options[:clear_cache] = false if @options[:clear_cache] == false
+      @validation_options[:clear_cache] = true if @@cache_schemas || @options[:clear_cache]
 
       @@mutex.synchronize { @base_schema = initialize_schema(schema_data) }
       @original_data = data
@@ -298,7 +298,7 @@ module JSON
       end
 
       def clear_cache
-        @@schemas = {} if @@cache_schemas == false
+        @@schemas = {}
       end
 
       def schemas

--- a/test/caching_test.rb
+++ b/test/caching_test.rb
@@ -9,7 +9,7 @@ class CachingTestTest < Minitest::Test
     }
     schema = JSON::Schema.new(initial_schema, URI)
     JSON::Validator.add_schema(schema)
-    assert_valid(URI, "foo")
+    assert_valid(URI, "foo", :clear_cache => false)
 
     initial_schema = {
       "type" => "number"

--- a/test/caching_test.rb
+++ b/test/caching_test.rb
@@ -1,0 +1,61 @@
+require File.expand_path('../support/test_helper', __FILE__)
+
+class CachingTestTest < Minitest::Test
+  URI = "http://example.com/test-schema.json"
+
+  def test_caching
+    initial_schema = {
+      "type" => "string"
+    }
+    schema = JSON::Schema.new(initial_schema, URI)
+    JSON::Validator.add_schema(schema)
+    assert_valid(URI, "foo")
+
+    initial_schema = {
+      "type" => "number"
+    }
+    schema = JSON::Schema.new(initial_schema, URI)
+    JSON::Validator.add_schema(schema)
+    assert_valid(URI, "foo")
+  end
+
+  def test_clear_cache
+    initial_schema = {
+      "type" => "string"
+    }
+    schema = JSON::Schema.new(initial_schema, URI)
+    JSON::Validator.add_schema(schema)
+    assert_valid(URI, "foo", :clear_cache => true)
+
+    initial_schema = {
+      "type" => "number"
+    }
+    schema = JSON::Schema.new(initial_schema, URI)
+    JSON::Validator.add_schema(schema)
+    assert_valid(URI, 123)
+  end
+
+  def test_cache_schemas
+    suppress_warnings do
+      JSON::Validator.cache_schemas = true
+    end
+
+    initial_schema = {
+      "type" => "string"
+    }
+    schema = JSON::Schema.new(initial_schema, URI)
+    JSON::Validator.add_schema(schema)
+    assert_valid(URI, "foo")
+
+    initial_schema = {
+      "type" => "number"
+    }
+    schema = JSON::Schema.new(initial_schema, URI)
+    JSON::Validator.add_schema(schema)
+    assert_valid(URI, 123)
+  ensure
+    suppress_warnings do
+      JSON::Validator.cache_schemas = false
+    end
+  end
+end

--- a/test/draft1_test.rb
+++ b/test/draft1_test.rb
@@ -1,8 +1,8 @@
 require File.expand_path('../support/test_helper', __FILE__)
 
 class Draft1Test < Minitest::Test
-  def schema_version
-    :draft1
+  def validation_errors(schema, data, options)
+    super(schema, data, :version => :draft1)
   end
 
   def exclusive_minimum

--- a/test/draft2_test.rb
+++ b/test/draft2_test.rb
@@ -1,8 +1,8 @@
 require File.expand_path('../support/test_helper', __FILE__)
 
 class Draft2Test < Minitest::Test
-  def schema_version
-    :draft2
+  def validation_errors(schema, data, options)
+    super(schema, data, :version => :draft2)
   end
 
   def exclusive_minimum

--- a/test/draft3_test.rb
+++ b/test/draft3_test.rb
@@ -2,8 +2,8 @@
 require File.expand_path('../support/test_helper', __FILE__)
 
 class Draft3Test < Minitest::Test
-  def schema_version
-    :draft3
+  def validation_errors(schema, data, options)
+    super(schema, data, :version => :draft3)
   end
 
   def exclusive_minimum

--- a/test/draft4_test.rb
+++ b/test/draft4_test.rb
@@ -2,8 +2,8 @@
 require File.expand_path('../support/test_helper', __FILE__)
 
 class Draft4Test < Minitest::Test
-  def schema_version
-    :draft4
+  def validation_errors(schema, data, options)
+    super(schema, data, :version => :draft4)
   end
 
   def exclusive_minimum

--- a/test/extended_schema_test.rb
+++ b/test/extended_schema_test.rb
@@ -12,15 +12,15 @@ class ExtendedSchemaTest < Minitest::Test
     end
   end
 
-  class ExtendedSchema < JSON::Schema::Validator
+  class ExtendedSchema < JSON::Schema::Draft3
     def initialize
       super
-      extend_schema_definition("http://json-schema.org/draft-03/schema#")
       @attributes["bitwise-and"] = BitwiseAndAttribute
+      @names = ["http://test.com/test.json"]
       @uri = Addressable::URI.parse("http://test.com/test.json")
     end
 
-    JSON::Validator.register_validator(self.new)
+    JSON::Validator.register_validator(ExtendedSchema.new)
   end
 
   def test_extended_schema_validation

--- a/test/list_option_test.rb
+++ b/test/list_option_test.rb
@@ -13,7 +13,7 @@ class ListOptionTest < Minitest::Test
     JSON::Validator.add_schema(schema)
 
     data = {"a" => 1}
-    assert_valid uri.to_s, data
+    assert_valid uri.to_s, data, clear_cache: false
 
     data = [{"a" => 1}]
     assert_valid uri.to_s, data, :list => true

--- a/test/support/number_validation.rb
+++ b/test/support/number_validation.rb
@@ -78,16 +78,5 @@ module NumberValidation
       # other types are disregarded
       assert_valid schema, {'a' => 'hi'}
     end
-
-    def test_multiple_of_zero
-      schema = {
-        'properties' => {
-          'a' => { multiple_of => 0 }
-        }
-      }
-
-      refute_valid schema, {'a' => 5}
-      refute_valid schema, {'a' => 0}
-    end
   end
 end

--- a/test/support/test_helper.rb
+++ b/test/support/test_helper.rb
@@ -9,6 +9,16 @@ Dir[File.join(File.expand_path('../', __FILE__), '*.rb')].each do |support_file|
 end
 
 class Minitest::Test
+  def suppress_warnings
+    old_verbose = $VERBOSE
+    $VERBOSE = nil
+    begin
+      yield
+    ensure
+      $VERBOSE = old_verbose
+    end
+  end
+
   def schema_fixture_path(filename)
     File.join(File.dirname(__FILE__), '../schemas', filename)
   end

--- a/test/support/test_helper.rb
+++ b/test/support/test_helper.rb
@@ -28,20 +28,17 @@ class Minitest::Test
   end
 
   def assert_valid(schema, data, options = {})
-    if !options.key?(:version) && respond_to?(:schema_version)
-      options = options.merge(:version => schema_version)
-    end
-
-    errors = JSON::Validator.fully_validate(schema, data, options)
+    errors = validation_errors(schema, data, options)
     assert_equal([], errors, "#{data.inspect} should be valid for schema:\n#{schema.inspect}")
   end
 
   def refute_valid(schema, data, options = {})
-    if !options.key?(:version) && respond_to?(:schema_version)
-      options = options.merge(:version => schema_version)
-    end
-
-    errors = JSON::Validator.fully_validate(schema, data, options)
+    errors = validation_errors(schema, data, options)
     refute_equal([], errors, "#{data.inspect} should be invalid for schema:\n#{schema.inspect}")
+  end
+
+  def validation_errors(schema, data, options)
+    options = { :clear_cache => true }.merge(options)
+    JSON::Validator.fully_validate(schema, data, options)
   end
 end

--- a/test/support/test_helper.rb
+++ b/test/support/test_helper.rb
@@ -38,7 +38,7 @@ class Minitest::Test
   end
 
   def validation_errors(schema, data, options)
-    options = { :clear_cache => true }.merge(options)
+    options = { :clear_cache => true, :validate_schema => true }.merge(options)
     JSON::Validator.fully_validate(schema, data, options)
   end
 end

--- a/test/validator_schema_reader_test.rb
+++ b/test/validator_schema_reader_test.rb
@@ -2,8 +2,10 @@ require File.expand_path('../support/test_helper', __FILE__)
 
 class ValidatorSchemaReaderTest < Minitest::Test
 
-  class MockReader
+  class MockReader < JSON::Schema::Reader
     def read(location)
+      return super unless location.to_s == 'http://any.url/at/all'
+
       schema = {
         '$schema' => 'http://json-schema.org/draft-04/schema#',
         'type' => 'string',
@@ -45,7 +47,7 @@ class ValidatorSchemaReaderTest < Minitest::Test
 
   def test_validate_list_with_reader
     reader = MockReader.new
-    schema = { '$ref' => 'http://what.ever/schema' }
+    schema = { '$ref' => 'http://any.url/at/all' }
     assert_valid schema, ['abc', 'def'], :schema_reader => reader, :list => true
     refute_valid schema, ['abc', 'a'], :schema_reader => reader, :list => true
   end


### PR DESCRIPTION
 I discovered that the flag we have to clear the cache after validation (`:clear_cache => true`) didn't actually work. I've added tests around that and fixed the problem. There were also issues with `JSON::Validator.cache_schemas`.

There was also some minor refactoring of the test helpers, to make clearing the cache and validating schemas the default, which wouldn't have worked before merging this.