### PR TITLE
Deprecated #extend_schema_definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   `JSON::Schema::RefAttribute` into `JSON::Util::URI`
 - Deprecated `JSON::Validator#validator_for` in favor of `JSON::Validator#validator_for_uri`
 - Deprecated `JSON::Validator.validate2` in favor of `JSON::Validator.validate!`
+- Deprecated `JSON::Schema::Validator#extend_schema_definition` in favour of subclassing
 
 ## [2.7.0] - 2016-09-29
 

--- a/README.md
+++ b/README.md
@@ -291,17 +291,17 @@ class BitwiseAndAttribute < JSON::Schema::Attribute
   def self.validate(current_schema, data, fragments, processor, validator, options = {})
     if data.is_a?(Integer) && data & current_schema.schema['bitwise-and'].to_i == 0
       message = "The property '#{build_fragment(fragments)}' did not evaluate  to true when bitwise-AND'd with  #{current_schema.schema['bitwise-or']}"
-      raise JSON::Schema::ValidationError.new(message, fragments, current_schema)
+      validation_error(processor, message, fragments, current_schema, self, options[:record_errors])
     end
   end
 end
 
-class ExtendedSchema < JSON::Schema::Validator
+class ExtendedSchema < JSON::Schema::Draft3
   def initialize
     super
-    extend_schema_definition("http://json-schema.org/draft-03/schema#")
     @attributes["bitwise-and"] = BitwiseAndAttribute
-    @uri = URI.parse("http://test.com/test.json")
+    @uri = JSON::Util::URI.parse("http://test.com/test.json")
+    @names = ["http://test.com/test.json"]
   end
 
   JSON::Validator.register_validator(self.new)

--- a/lib/json-schema/schema/validator.rb
+++ b/lib/json-schema/schema/validator.rb
@@ -14,6 +14,7 @@ module JSON
       end
 
       def extend_schema_definition(schema_uri)
+        warn "[DEPRECATION NOTICE] The preferred way to extend a Validator is by subclassing, rather than #extend_schema_definition. This method will be removed in version >= 3."
         validator = JSON::Validator.validator_for_uri(schema_uri)
         @attributes.merge!(validator.attributes)
       end

--- a/test/extended_schema_test.rb
+++ b/test/extended_schema_test.rb
@@ -18,6 +18,7 @@ class ExtendedSchemaTest < Minitest::Test
       @attributes["bitwise-and"] = BitwiseAndAttribute
       @names = ["http://test.com/test.json"]
       @uri = Addressable::URI.parse("http://test.com/test.json")
+      @names = ["http://test.com/test.json"]
     end
 
     JSON::Validator.register_validator(ExtendedSchema.new)


### PR DESCRIPTION
There are two ways right now to extend a schema, one is by subclassing
either an existing validator (eg. `JSON::Schema::Draft4`) and the other is
by subclassing the base validator class (`JSON::Schema::Validator`) and
calling `extend_schema_definition` in the initializer. This method
merges the recognised json schema properties of another validator into
your new validator. Unfortunately this is effectively the same as
subclassing. What's worse, `extend_schema_definition` does not merge in
any of the other characteristics of a validator (eg. the formats or
names etc needed for a schema to work). All of the validator classes
that come with json-schema use subclassing, rather than
`extend_schema_definition`.

Because of this, I propose that we should deprecate
`extend_schema_definition` and encourage people to subclass instead.
