### PR TITLE
Deprecated `JSON::Validator#validate2`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Moved `JSON::Validator.absolutize_ref` and the ref manipulating code in
   `JSON::Schema::RefAttribute` into `JSON::Util::URI`
 - Deprecated `JSON::Validator#validator_for` in favor of `JSON::Validator#validator_for_uri`
+- Deprecated `JSON::Validator.validate2` in favor of `JSON::Validator.validate!`
 
 ## [2.7.0] - 2016-09-29
 

--- a/lib/json-schema/validator.rb
+++ b/lib/json-schema/validator.rb
@@ -253,7 +253,11 @@ module JSON
         validator = new(schema, data, opts)
         validator.validate
       end
-      alias_method 'validate2', 'validate!'
+
+      def validate2(schema, data, opts={})
+        warn "[DEPRECATION NOTICE] JSON::Validator#validate2 has been replaced by JSON::Validator#validate! and will be removed in version >= 3. Please use the #validate! method instead."
+        validate!(schema, data, opts)
+      end
 
       def validate_json!(schema, data, opts={})
         validate!(schema, data, opts.merge(:json => true))


### PR DESCRIPTION
`JSON::Validator#validate!` is the accepted way to validate and raise
exceptions if the data is invalid, but there is also the `#validate2`
method. From my point of view this is a legacy method and I think we
should encourage people to use `#validate!`
