### PR TITLE
Made sure all validate methods go through the same call chain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+- Made all `validate*` methods on `JSON::Validator` ultimately call `validate!`
+
 ## [2.6.2] - 2016-05-13
 
 ### Fixed


### PR DESCRIPTION
Right now when a schema is validated, we perform a different call path
depending on which of the validate methods is called. Schema validation
has it's own path too.

I've changed this so everything is validated via
`JSON::Validator#validate!`, all other validate methods ultimately call
that. This means that the varied validate class methods on `Validator`
are simplified and just add or remove validation options.