### PR TITLE
Removed the ruby 1.8 build from travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: "ruby"
 
 rvm:
-  - "1.8"
   - "1.9"
   - "2.0"
   - "2.1"
@@ -23,5 +22,3 @@ matrix:
       gemfile: "gemfiles/Gemfile.yajl-ruby.x"
     - rvm: "2.3.1"
       gemfile: "gemfiles/Gemfile.uuidtools.x"
-  allow_failures:
-    - rvm: "1.8"

--- a/Gemfile
+++ b/Gemfile
@@ -2,4 +2,4 @@ source "https://rubygems.org"
 
 gemspec
 
-gem "json", ">= 1.7", :platforms => [:mri_18, :mri_19]
+gem "json", ">= 1.7", :platforms => :mri_19

--- a/json-schema.gemspec
+++ b/json-schema.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.files = Dir[ "lib/**/*", "resources/*.json" ]
   s.require_path = "lib"
   s.extra_rdoc_files = ["README.md","LICENSE.md"]
-  s.required_ruby_version = ">= 1.8.7"
+  s.required_ruby_version = ">= 1.9"
   s.license = "MIT"
   s.required_rubygems_version = ">= 1.8"
 


### PR DESCRIPTION
Ruby 1.8 support hasn't worked for some time, and we've been ignoring
build failures on travis for ruby 1.8. Here are some examples of code
that has already been released, which is incompatible with ruby 1.8:

* DateTime.rfc3339 was only introduced in ruby 1.9
* Hash#select was changed to return a Hash in ruby 1.9
* Hash keys became ordered in ruby 1.9

I haven't added anything to the changelog because this isn't a new
thing, it's been the reality for some time.