### PR TITLE
Moved Validator#absolutized_uri and RefAttribute's ref parsing into the URI module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - Made the `:clear_cache` option for `validate` also clear the URI parse cache
+- Moved `JSON::Validator.absolutize_ref` and the ref manipulating code in
+  `JSON::Schema::RefAttribute` into `JSON::Util::URI`
 
 ## [2.7.0] - 2016-09-29
 

--- a/lib/json-schema/attributes/ref.rb
+++ b/lib/json-schema/attributes/ref.rb
@@ -22,23 +22,7 @@ module JSON
       def self.get_referenced_uri_and_schema(s, current_schema, validator)
         uri,schema = nil,nil
 
-        temp_uri = JSON::Util::URI.parse(s['$ref'])
-        temp_uri.defer_validation do
-          if temp_uri.relative?
-            temp_uri.merge!(current_schema.uri)
-            # Check for absolute path
-            path, fragment = s['$ref'].split("#")
-            if path.nil? || path == ''
-              temp_uri.path = current_schema.uri.path
-            elsif path[0,1] == "/"
-              temp_uri.path = Pathname.new(path).cleanpath.to_s
-            else
-              temp_uri.join!(path)
-            end
-            temp_uri.fragment = fragment
-          end
-          temp_uri.fragment = "" if temp_uri.fragment.nil? || temp_uri.fragment.empty?
-        end
+        temp_uri = JSON::Util::URI.normalize_ref(s['$ref'], current_schema.uri)
 
         # Grab the parent schema from the schema list
         schema_key = temp_uri.to_s.split("#")[0] + "#"

--- a/lib/json-schema/validator.rb
+++ b/lib/json-schema/validator.rb
@@ -131,23 +131,12 @@ module JSON
     end
 
     def load_ref_schema(parent_schema, ref)
-      schema_uri = absolutize_ref_uri(ref, parent_schema.uri)
+      schema_uri = JSON::Util::URI.absolutize_ref(ref, parent_schema.uri)
       return true if self.class.schema_loaded?(schema_uri)
 
       schema = @options[:schema_reader].read(schema_uri)
       self.class.add_schema(schema)
       build_schemas(schema)
-    end
-
-    def absolutize_ref_uri(ref, parent_schema_uri)
-      ref_uri = JSON::Util::URI.strip_fragment(ref)
-
-      return ref_uri if ref_uri.absolute?
-      # This is a self reference and thus the schema does not need to be re-loaded
-      return parent_schema_uri if ref_uri.path.empty?
-
-      uri = JSON::Util::URI.strip_fragment(parent_schema_uri.dup)
-      Util::URI.normalized_uri(uri.join(ref_uri.path))
     end
 
     # Build all schemas with IDs, mapping out the namespace

--- a/test/uri_parsing_test.rb
+++ b/test/uri_parsing_test.rb
@@ -2,16 +2,6 @@
 require File.expand_path('../support/test_helper', __FILE__)
 
 class UriParsingTest < Minitest::Test
-  def populate_cache_with(str, &blk)
-    cached_uri = Addressable::URI.parse(str)
-    Addressable::URI.stub(:parse, cached_uri, &blk)
-    cached_uri
-  end
-
-  def teardown
-    JSON::Util::URI.clear_cache
-  end
-
   def test_asian_characters
     schema = {
       "$schema"=> "http://json-schema.org/draft-04/schema#",
@@ -73,108 +63,5 @@ class UriParsingTest < Minitest::Test
     data = {"first" => "john"}
     schema = "test/schemas/ref john with spaces schema.json"
     assert_valid schema, data
-  end
-
-  def test_normalized_uri
-    str = "https://www.google.com/search"
-    uri = Addressable::URI.new(scheme: 'https',
-                               host: 'www.google.com',
-                               path: 'search')
-    assert_equal uri, JSON::Util::URI.normalized_uri(str, '/home')
-  end
-
-  def test_normalized_uri_with_empty_fragment
-    str = "https://www.google.com/search#"
-    uri = Addressable::URI.new(scheme: 'https',
-                               host: 'www.google.com',
-                               path: 'search',
-                               fragment: nil)
-    assert_equal uri, JSON::Util::URI.normalized_uri(str, '/home')
-  end
-
-  def test_normalized_uri_with_fragment
-    str = "https://www.google.com/search#foo"
-    uri = Addressable::URI.new(scheme: 'https',
-                               host: 'www.google.com',
-                               path: 'search',
-                               fragment: 'foo')
-    assert_equal uri, JSON::Util::URI.normalized_uri(str, '/home')
-  end
-
-  def test_normalized_uri_for_absolute_path
-    str = "/foo/bar.json"
-    uri = Addressable::URI.new(scheme: 'file',
-                               path: '///foo/bar.json')
-    assert_equal uri, JSON::Util::URI.normalized_uri(str, '/home')
-  end
-
-  def test_normalized_uri_for_relartive_path
-    str = "foo/bar.json"
-    uri = Addressable::URI.new(scheme: 'file',
-                               path: '///home/foo/bar.json')
-    assert_equal uri, JSON::Util::URI.normalized_uri(str, '/home')
-  end
-
-  def test_uri_parse
-    str = "https://www.google.com/search"
-    uri = Addressable::URI.new(scheme: 'https',
-                               host: 'www.google.com',
-                               path: 'search')
-    assert_equal uri, JSON::Util::URI.parse(str)
-  end
-
-  def test_invalid_uri_parse
-    uri = ":::::::"
-    assert_raises(JSON::Schema::UriError) do
-      JSON::Util::URI.parse(uri)
-    end
-  end
-
-  def test_normalization_cache
-    cached_uri = populate_cache_with('www.google.com') do
-      JSON::Util::URI.normalized_uri('foo')
-    end
-
-    assert_equal(cached_uri, JSON::Util::URI.normalized_uri('foo'))
-
-    JSON::Util::URI.clear_cache
-
-    refute_equal(cached_uri, JSON::Util::URI.normalized_uri('foo'))
-  end
-
-  def test_parse_cache
-    cached_uri = populate_cache_with('www.google.com') do
-      JSON::Util::URI.parse('foo')
-    end
-
-    assert_equal(cached_uri, JSON::Util::URI.parse('foo'))
-
-    JSON::Util::URI.clear_cache
-
-    refute_equal(cached_uri, JSON::Util::URI.parse('foo'))
-  end
-
-  def test_validator_clear_cache_for_normalized_uri
-    cached_uri = populate_cache_with('www.google.com') do
-      JSON::Util::URI.normalized_uri('foo')
-    end
-
-    assert_equal(cached_uri, JSON::Util::URI.normalized_uri('foo'))
-
-    validation_errors({"type" => "string"}, "foo", :clear_cache => true)
-
-    refute_equal(cached_uri, JSON::Util::URI.normalized_uri('foo'))
-  end
-
-  def test_validator_clear_cache_for_parse
-    cached_uri = populate_cache_with('www.google.com') do
-      JSON::Util::URI.parse('foo')
-    end
-
-    assert_equal(cached_uri, JSON::Util::URI.parse('foo'))
-
-    validation_errors({"type" => "string"}, "foo", :clear_cache => true)
-
-    refute_equal(cached_uri, JSON::Util::URI.parse('foo'))
   end
 end

--- a/test/uri_util_test.rb
+++ b/test/uri_util_test.rb
@@ -1,0 +1,196 @@
+require File.expand_path('../support/test_helper', __FILE__)
+
+class UriUtilTest < Minitest::Test
+  def populate_cache_with(str, &blk)
+    cached_uri = Addressable::URI.parse(str)
+    Addressable::URI.stub(:parse, cached_uri, &blk)
+    cached_uri
+  end
+
+  def teardown
+    JSON::Util::URI.clear_cache
+  end
+
+  def test_normalized_uri
+    str = "https://www.google.com/search"
+    uri = Addressable::URI.new(scheme: 'https',
+                               host: 'www.google.com',
+                               path: 'search')
+    assert_equal uri, JSON::Util::URI.normalized_uri(str, '/home')
+  end
+
+  def test_normalized_uri_with_empty_fragment
+    str = "https://www.google.com/search#"
+    uri = Addressable::URI.new(scheme: 'https',
+                               host: 'www.google.com',
+                               path: 'search',
+                               fragment: nil)
+    assert_equal uri, JSON::Util::URI.normalized_uri(str, '/home')
+  end
+
+  def test_normalized_uri_with_fragment
+    str = "https://www.google.com/search#foo"
+    uri = Addressable::URI.new(scheme: 'https',
+                               host: 'www.google.com',
+                               path: 'search',
+                               fragment: 'foo')
+    assert_equal uri, JSON::Util::URI.normalized_uri(str, '/home')
+  end
+
+  def test_normalized_uri_for_absolute_path
+    str = "/foo/bar.json"
+    uri = Addressable::URI.new(scheme: 'file',
+                               path: '///foo/bar.json')
+    assert_equal uri, JSON::Util::URI.normalized_uri(str, '/home')
+  end
+
+  def test_normalized_uri_for_relartive_path
+    str = "foo/bar.json"
+    uri = Addressable::URI.new(scheme: 'file',
+                               path: '///home/foo/bar.json')
+    assert_equal uri, JSON::Util::URI.normalized_uri(str, '/home')
+  end
+
+  def test_uri_parse
+    str = "https://www.google.com/search"
+    uri = Addressable::URI.new(scheme: 'https',
+                               host: 'www.google.com',
+                               path: 'search')
+    assert_equal uri, JSON::Util::URI.parse(str)
+  end
+
+  def test_invalid_uri_parse
+    uri = ":::::::"
+    assert_raises(JSON::Schema::UriError) do
+      JSON::Util::URI.parse(uri)
+    end
+  end
+
+  def test_normalization_cache
+    cached_uri = populate_cache_with('www.google.com') do
+      JSON::Util::URI.normalized_uri('foo')
+    end
+
+    assert_equal(cached_uri, JSON::Util::URI.normalized_uri('foo'))
+
+    JSON::Util::URI.clear_cache
+
+    refute_equal(cached_uri, JSON::Util::URI.normalized_uri('foo'))
+  end
+
+  def test_parse_cache
+    cached_uri = populate_cache_with('www.google.com') do
+      JSON::Util::URI.parse('foo')
+    end
+
+    assert_equal(cached_uri, JSON::Util::URI.parse('foo'))
+
+    JSON::Util::URI.clear_cache
+
+    refute_equal(cached_uri, JSON::Util::URI.parse('foo'))
+  end
+
+  def test_validator_clear_cache_for_normalized_uri
+    cached_uri = populate_cache_with('www.google.com') do
+      JSON::Util::URI.normalized_uri('foo')
+    end
+
+    assert_equal(cached_uri, JSON::Util::URI.normalized_uri('foo'))
+
+    validation_errors({"type" => "string"}, "foo", :clear_cache => true)
+
+    refute_equal(cached_uri, JSON::Util::URI.normalized_uri('foo'))
+  end
+
+  def test_validator_clear_cache_for_parse
+    cached_uri = populate_cache_with('www.google.com') do
+      JSON::Util::URI.parse('foo')
+    end
+
+    assert_equal(cached_uri, JSON::Util::URI.parse('foo'))
+
+    validation_errors({"type" => "string"}, "foo", :clear_cache => true)
+
+    refute_equal(cached_uri, JSON::Util::URI.parse('foo'))
+  end
+
+  def test_ref_fragment_path
+    uri = '#some-thing'
+    base = 'http://www.example.com/foo/#bar'
+
+    assert_equal Addressable::URI.parse('http://www.example.com/foo/#some-thing'), JSON::Util::URI.normalize_ref(uri, base)
+    assert_equal Addressable::URI.parse('http://www.example.com/foo/#'), JSON::Util::URI.absolutize_ref(uri, base)
+  end
+
+  def test_ref_file_path
+    uri = '/some/thing'
+    base = 'http://www.example.com/foo/#bar'
+
+    assert_equal Addressable::URI.parse('http://www.example.com/some/thing#'), JSON::Util::URI.normalize_ref(uri, base)
+    assert_equal Addressable::URI.parse('http://www.example.com/some/thing#'), JSON::Util::URI.absolutize_ref(uri, base)
+  end
+
+  def test_ref_uri
+    uri = 'http://foo-bar.com'
+    base = 'http://www.example.com/foo/#bar'
+
+    assert_equal Addressable::URI.parse('http://foo-bar.com/#'), JSON::Util::URI.normalize_ref(uri, base)
+    assert_equal Addressable::URI.parse('http://foo-bar.com/#'), JSON::Util::URI.absolutize_ref(uri, base)
+  end
+
+  def test_ref_uri_with_path
+    uri = 'http://foo-bar.com/some/thing'
+    base = 'http://www.example.com/foo/#bar'
+
+    assert_equal Addressable::URI.parse('http://foo-bar.com/some/thing#'), JSON::Util::URI.normalize_ref(uri, base)
+    assert_equal Addressable::URI.parse('http://foo-bar.com/some/thing#'), JSON::Util::URI.absolutize_ref(uri, base)
+  end
+
+  def test_ref_uri_with_fragment
+    uri = 'http://foo-bar.com/some/thing#foo'
+    base = 'http://www.example.com/hello/#world'
+
+    assert_equal Addressable::URI.parse('http://foo-bar.com/some/thing#foo'), JSON::Util::URI.normalize_ref(uri, base)
+    assert_equal Addressable::URI.parse('http://foo-bar.com/some/thing#'), JSON::Util::URI.absolutize_ref(uri, base)
+  end
+
+  def test_ref_uri_with_fragment_and_base_with_no_fragment
+    uri = 'http://foo-bar.com/some/thing#foo'
+    base = 'http://www.example.com/hello'
+
+    assert_equal Addressable::URI.parse('http://foo-bar.com/some/thing#foo'), JSON::Util::URI.normalize_ref(uri, base)
+    assert_equal Addressable::URI.parse('http://foo-bar.com/some/thing#'), JSON::Util::URI.absolutize_ref(uri, base)
+  end
+
+  def test_ref_relative_path
+    uri = 'hello/world'
+    base = 'http://www.example.com/foo/#bar'
+
+    assert_equal Addressable::URI.parse('http://www.example.com/foo/hello/world#'), JSON::Util::URI.normalize_ref(uri, base)
+    assert_equal Addressable::URI.parse('http://www.example.com/foo/hello/world#'), JSON::Util::URI.absolutize_ref(uri, base)
+  end
+
+  def test_ref_addressable_uri_with_host
+    uri = Addressable::URI.new(:host => 'foo-bar.com')
+    base = 'http://www.example.com/hello/#world'
+
+    assert_equal Addressable::URI.parse('http://www.example.com/foo-bar.com#'), JSON::Util::URI.normalize_ref(uri, base)
+    assert_equal Addressable::URI.parse('http://www.example.com/hello/#world'), JSON::Util::URI.absolutize_ref(uri, base)
+  end
+
+  def test_ref_addressable_uri_with_host_and_path
+    uri = Addressable::URI.new(:host => 'foo-bar.com', :path => '/hello/world')
+    base = 'http://www.example.com/a/#b'
+
+    assert_equal Addressable::URI.parse('http://www.example.com/foo-bar.com/hello/world#'), JSON::Util::URI.normalize_ref(uri, base)
+    assert_equal Addressable::URI.parse('http://www.example.com/hello/world'), JSON::Util::URI.absolutize_ref(uri, base)
+  end
+
+  def test_ref_addressable_uri_with_shceme_host_and_path
+    uri = Addressable::URI.new(:scheme => 'https', :host => 'foo-bar.com', :path => '/hello/world')
+    base = 'http://www.example.com/a/#b'
+
+    assert_equal Addressable::URI.parse('https://foo-bar.com/hello/world#'), JSON::Util::URI.normalize_ref(uri, base)
+    assert_equal Addressable::URI.parse('https://foo-bar.com/hello/world'), JSON::Util::URI.absolutize_ref(uri, base)
+  end
+end


### PR DESCRIPTION
I just noticed that we have this URI processing method in Validator, and
similar code in RefAttribute. I had thought we'd moved all of these into
the URI module, but these must have been missed.

I've taken the opportunity to tidy them up slightly too.

One day we might be able to unify these methods