### PR TITLE
Simplified `#validator_for` methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Made the `:clear_cache` option for `validate` also clear the URI parse cache
 - Moved `JSON::Validator.absolutize_ref` and the ref manipulating code in
   `JSON::Schema::RefAttribute` into `JSON::Util::URI`
+- Deprecated `JSON::Validator#validator_for` in favor of `JSON::Validator#validator_for_uri`
 
 ## [2.7.0] - 2016-09-29
 

--- a/lib/json-schema/schema.rb
+++ b/lib/json-schema/schema.rb
@@ -21,7 +21,7 @@ module JSON
 
       # If there is a $schema on this schema, use it to determine which validator to use
       if @schema['$schema']
-        @validator = JSON::Validator.validator_for(@schema['$schema'])
+        @validator = JSON::Validator.validator_for_uri(@schema['$schema'])
       elsif parent_validator
         @validator = parent_validator
       else

--- a/lib/json-schema/schema/validator.rb
+++ b/lib/json-schema/schema/validator.rb
@@ -14,7 +14,7 @@ module JSON
       end
 
       def extend_schema_definition(schema_uri)
-        validator = JSON::Validator.validator_for(schema_uri)
+        validator = JSON::Validator.validator_for_uri(schema_uri)
         @attributes.merge!(validator.attributes)
       end
 


### PR DESCRIPTION
Right now there is:

* `#validator_for`
* `#validator_for_uri`
* `#validator_for_name`
* `#validators_for_names`

But in reality all delegate to either `#validator_for_uri` or
`#validator_for_name`. This is confusing, and obfuscates what's really
going on.

I've removed `#validators_for_names` (which was a private method anyway)
and deprecated the alias of `#validator_for`.