### PR TITLE
Item partial tuples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Made sure we really do clear the cache when instructed to
 - It's now possible to use reserved words in property names
 - Removed support for setting "extends" to a string (it's invalid json-schema - use a "$ref" instead)
+- Relaxed 'items' and 'allowedItems' validation to permit arrays to pass even
+  when they contain fewer elements than the 'items' array.  To require full tuples,
+  use 'minItems'.
 
 ### Changed
 - Made all `validate*` methods on `JSON::Validator` ultimately call `validate!`

--- a/lib/json-schema/attributes/additionalitems.rb
+++ b/lib/json-schema/attributes/additionalitems.rb
@@ -11,7 +11,7 @@ module JSON
 
         case schema['additionalItems']
         when false
-          if schema['items'].length != data.length
+          if schema['items'].length < data.length
             message = "The property '#{build_fragment(fragments)}' contains additional array elements outside of the schema when none are allowed"
             validation_error(processor, message, fragments, current_schema, self, options[:record_errors])
           end

--- a/lib/json-schema/attributes/items.rb
+++ b/lib/json-schema/attributes/items.rb
@@ -16,7 +16,7 @@ module JSON
 
         when Array
           items.each_with_index do |item_schema, i|
-            next unless i < data.length
+            break if i >= data.length
             schema = JSON::Schema.new(item_schema, current_schema.uri, validator)
             schema.validate(data[i], fragments + [i.to_s], processor, options)
           end

--- a/lib/json-schema/attributes/items.rb
+++ b/lib/json-schema/attributes/items.rb
@@ -16,6 +16,7 @@ module JSON
 
         when Array
           items.each_with_index do |item_schema, i|
+            next unless i < data.length
             schema = JSON::Schema.new(item_schema, current_schema.uri, validator)
             schema.validate(data[i], fragments + [i.to_s], processor, options)
           end

--- a/test/support/array_validation.rb
+++ b/test/support/array_validation.rb
@@ -25,7 +25,9 @@ module ArrayValidation
       assert_valid schema, ['b', 1]
       assert_valid schema, ['b', 1, nil]
       refute_valid schema, [1, 'b']
-      refute_valid schema, []
+      assert_valid schema, []
+      assert_valid schema, ['b']
+      assert_valid schema, ['b', 1, 25]
     end
 
     def test_minitems
@@ -62,6 +64,8 @@ module ArrayValidation
       }
 
       assert_valid schema, [1, 'string']
+      assert_valid schema, [1]
+      assert_valid schema, []
       refute_valid schema, [1, 'string', 2]
       refute_valid schema, ['string', 1]
     end


### PR DESCRIPTION
Currently, when 'items' is an array of schemas, validation will fail if the target array has fewer elements than the 'items' array.  This conflicts with the spec, which allows for partial (or even empty) tuples to pass validation unless 'minItems' is also set.

See the relevant section of [Understanding JSON Schema](https://spacetelescope.github.io/understanding-json-schema/reference/array.html#tuple-validation) for examples of this.  Note specifically the statement: "It's okay to not provide all the items."

This PR modifies the array_validation tests to check for this condition and fixes the corresponding code in the attributes directory.