### PR TITLE
Restricted the ruby 1.9 build to json < 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: "ruby"
 
 rvm:
-  - "1.9"
   - "2.0"
   - "2.1"
   - "2.2"
@@ -16,6 +15,8 @@ install:
 
 matrix:
   include:
+    - rvm: "1.9"
+      gemfile: "gemfiles/Gemfile.json_v1.x"
     - rvm: "2.3.1"
       gemfile: "gemfiles/Gemfile.multi_json.x"
     - rvm: "2.3.1"

--- a/gemfiles/Gemfile.json_v1.x
+++ b/gemfiles/Gemfile.json_v1.x
@@ -1,0 +1,5 @@
+source "https://rubygems.org"
+
+gemspec :path => "../"
+
+gem "json", "~> 1.0"


### PR DESCRIPTION
Version 2.0 of the json gem requires ruby 2+. We should continue
supporting ruby 1.9, but to do so we need to make sure that travis uses
version 1 of the json gem.

I've done this by adding a custom gemfile for ruby 1.9 that restricts
json to version 1.