### PR TITLE
Use latest json-schema draft in tests by default

### DIFF
--- a/test/extended_schema_test.rb
+++ b/test/extended_schema_test.rb
@@ -44,7 +44,6 @@ class ExtendedSchemaTest < Minitest::Test
   def test_unextended_schema
     # Verify that using the original schema disregards the `bitwise-and` property
     schema = {
-      "$schema" => "http://json-schema.org/draft-03/schema#",
       "properties" => {
         "a" => {
           "bitwise-and" => 1

--- a/test/full_validation_test.rb
+++ b/test/full_validation_test.rb
@@ -5,11 +5,10 @@ class FullValidationTest < Minitest::Test
   def test_full_validation
     data = {"b" => {"a" => 5}}
     schema = {
-      "$schema" => "http://json-schema.org/draft-03/schema#",
       "type" => "object",
+      "required" => ["b"],
       "properties" => {
         "b" => {
-          "required" => true
         }
       }
     }
@@ -19,11 +18,10 @@ class FullValidationTest < Minitest::Test
 
     data = {"c" => 5}
     schema = {
-      "$schema" => "http://json-schema.org/draft-03/schema#",
       "type" => "object",
+      "required" => ["b"],
       "properties" => {
         "b" => {
-          "required" => true
         },
         "c" => {
           "type" => "string"
@@ -38,7 +36,6 @@ class FullValidationTest < Minitest::Test
   def test_full_validation_with_union_types
     data = {"b" => 5}
     schema = {
-      "$schema" => "http://json-schema.org/draft-03/schema#",
       "type" => "object",
       "properties" => {
         "b" => {
@@ -51,7 +48,6 @@ class FullValidationTest < Minitest::Test
     assert(errors.empty?)
 
     schema = {
-      "$schema" => "http://json-schema.org/draft-03/schema#",
       "type" => "object",
       "properties" => {
         "b" => {
@@ -111,11 +107,10 @@ class FullValidationTest < Minitest::Test
   def test_full_validation_with_object_errors
     data = {"b" => {"a" => 5}}
     schema = {
-      "$schema" => "http://json-schema.org/draft-03/schema#",
       "type" => "object",
+      "required" => ["b"],
       "properties" => {
         "b" => {
-          "required" => true
         }
       }
     }
@@ -125,11 +120,10 @@ class FullValidationTest < Minitest::Test
 
     data = {"c" => 5}
     schema = {
-      "$schema" => "http://json-schema.org/draft-03/schema#",
       "type" => "object",
+      "required" => ["b"],
       "properties" => {
         "b" => {
-          "required" => true
         },
         "c" => {
           "type" => "string"
@@ -138,27 +132,28 @@ class FullValidationTest < Minitest::Test
     }
 
     errors = JSON::Validator.fully_validate(schema,data,:errors_as_objects => true)
+
     assert(errors.length == 2)
-    assert(errors[0][:failed_attribute] == "Properties")
+    assert(errors[0][:failed_attribute] == "Required")
     assert(errors[0][:fragment] == "#/")
-    assert(errors[1][:failed_attribute] == "Type")
+    assert(errors[1][:failed_attribute] == "TypeV4")
     assert(errors[1][:fragment] == "#/c")
   end
 
   def test_full_validation_with_nested_required_properties
     schema = {
-      "$schema" => "http://json-schema.org/draft-03/schema#",
       "type" => "object",
+      "required" => ["x"],
       "properties" => {
         "x" => {
-          "required" => true,
           "type" => "object",
+          "required" => ["a", "b"],
           "properties" => {
-            "a" => {"type"=>"integer","required"=>true},
-            "b" => {"type"=>"integer","required"=>true},
-            "c" => {"type"=>"integer","required"=>false},
-            "d" => {"type"=>"integer","required"=>false},
-            "e" => {"type"=>"integer","required"=>false},
+            "a" => {"type"=>"integer"},
+            "b" => {"type"=>"integer"},
+            "c" => {"type"=>"integer"},
+            "d" => {"type"=>"integer"},
+            "e" => {"type"=>"integer"},
           }
         }
       }
@@ -168,27 +163,27 @@ class FullValidationTest < Minitest::Test
     errors = JSON::Validator.fully_validate(schema,data,:errors_as_objects => true)
     assert_equal 2, errors.length
     assert_equal '#/x', errors[0][:fragment]
-    assert_equal 'Properties', errors[0][:failed_attribute]
+    assert_equal 'Required', errors[0][:failed_attribute]
     assert_equal '#/x/e', errors[1][:fragment]
-    assert_equal 'Type', errors[1][:failed_attribute]
+    assert_equal 'TypeV4', errors[1][:failed_attribute]
   end
 
   def test_full_validation_with_nested_required_propertiesin_array
     schema = {
-      "$schema" => "http://json-schema.org/draft-03/schema#",
       "type" => "object",
+      "required" => ["x"],
       "properties" => {
         "x" => {
-          "required" => true,
           "type" => "array",
           "items" => {
             "type" => "object",
+            "required" => ["a", "b"],
             "properties" => {
-              "a" => {"type"=>"integer","required"=>true},
-              "b" => {"type"=>"integer","required"=>true},
-              "c" => {"type"=>"integer","required"=>false},
-              "d" => {"type"=>"integer","required"=>false},
-              "e" => {"type"=>"integer","required"=>false},
+              "a" => {"type"=>"integer"},
+              "b" => {"type"=>"integer"},
+              "c" => {"type"=>"integer"},
+              "d" => {"type"=>"integer"},
+              "e" => {"type"=>"integer"},
             }
           }
         }
@@ -201,8 +196,8 @@ class FullValidationTest < Minitest::Test
     errors = JSON::Validator.fully_validate(schema,data,:errors_as_objects => true)
     assert_equal 2, errors.length
     assert_equal '#/x/0', errors[0][:fragment]
-    assert_equal 'Properties', errors[0][:failed_attribute]
+    assert_equal 'Required', errors[0][:failed_attribute]
     assert_equal '#/x/1/e', errors[1][:fragment]
-    assert_equal 'Type', errors[1][:failed_attribute]
+    assert_equal 'TypeV4', errors[1][:failed_attribute]
   end
 end

--- a/test/schemas/extends_and_additionalProperties_false_schema.json
+++ b/test/schemas/extends_and_additionalProperties_false_schema.json
@@ -1,21 +1,17 @@
 {
-  "$schema": "http://json-schema.org/draft-03/schema#",
   "type": "object",
   "extends": {"$ref":"inner_schema.json#"},
   "properties": {
     "outerA": {
       "description": "blah",
-      "required": false,
       "additionalProperties": false,
       "properties": {
         "outerA1": {
-		  "type":"boolean",
-          "required": false
+          "type":"boolean"
         }
       }
     },
     "outerB": {
-      "required": false,
       "type": "array",
       "minItems": 1,
       "maxItems": 50,
@@ -26,8 +22,7 @@
     },
     "outerC": {
       "description": "blah",
-      "type":"boolean",
-      "required": false
+      "type":"boolean"
     }
   },
   "additionalProperties": false

--- a/test/schemas/extends_and_patternProperties_schema.json
+++ b/test/schemas/extends_and_patternProperties_schema.json
@@ -1,21 +1,17 @@
 {
-  "$schema": "http://json-schema.org/draft-03/schema#",
   "type": "object",
   "extends": {"$ref":"inner_schema.json#"},
   "patternProperties": {
     "outerA": {
       "description": "blah",
-      "required": false,
       "additionalProperties": false,
       "properties": {
         "outerA1": {
-		  "type":"boolean",
-          "required": false
+          "type":"boolean"
         }
       }
     },
     "outerB": {
-      "required": false,
       "type": "array",
       "minItems": 1,
       "maxItems": 50,
@@ -26,8 +22,7 @@
     },
     "outerC": {
       "description": "blah",
-      "type":"boolean",
-      "required": false
+      "type":"boolean"
     }
   }
 }

--- a/test/schemas/good_schema_1.json
+++ b/test/schemas/good_schema_1.json
@@ -1,10 +1,9 @@
 {
-  "$schema" : "http://json-schema.org/draft-03/schema#",
   "type" : "object",
   "properties" : {
     "a" : {
-      "type" : "integer",
-      "required" : true
+      "type" : "integer"
     }
-  }
+  },
+  "required": ["a"]
 }

--- a/test/schemas/good_schema_2.json
+++ b/test/schemas/good_schema_2.json
@@ -1,10 +1,9 @@
 {
-  "$schema" : "http://json-schema.org/draft-03/schema#",
   "type" : "object",
   "properties" : {
     "b" : {
-      "required" : true,
       "$ref" : "good_schema_1.json"
     }
-  }
+  },
+  "required": ["b"]
 }

--- a/test/schemas/good_schema_extends1.json
+++ b/test/schemas/good_schema_extends1.json
@@ -1,10 +1,8 @@
 {
-  "$schema" : "http://json-schema.org/draft-03/schema#",
   "type" : "object",
   "extends": {"$ref": "good_schema_1.json"},
   "properties" : {
     "c" : {
-      "required" : false
     }
   }
 }

--- a/test/schemas/good_schema_extends2.json
+++ b/test/schemas/good_schema_extends2.json
@@ -1,5 +1,4 @@
 {
-  "$schema" : "http://json-schema.org/draft-03/schema#",
   "type" : "object",
   "extends": [
     {"$ref": "good_schema_1.json"},
@@ -7,7 +6,6 @@
   ],
   "properties" : {
     "c" : {
-      "required" : false
     }
   }
 }

--- a/test/schemas/inner_schema.json
+++ b/test/schemas/inner_schema.json
@@ -1,20 +1,16 @@
 {
-  "$schema": "http://json-schema.org/draft-03/schema#",
   "type": "object",
   "properties": {
     "innerA": {
       "description": "blah",
-      "type":"boolean",
-      "required": false
+      "type":"boolean"
     },
     "innerB": {
       "description": "blah",
-      "type":"boolean",
-      "required": false
+      "type":"boolean"
     },
     "innerC": {
       "description": "blah",
-      "required": false,
       "type": "boolean"
     }
   }

--- a/test/support/strict_validation.rb
+++ b/test/support/strict_validation.rb
@@ -56,7 +56,6 @@ module StrictValidation
 
   def test_strict_properties_pattern_props
     schema = {
-      "$schema" => "http://json-schema.org/draft-03/schema#",
       "properties" => {
         "a" => {"type" => "string"},
         "b" => {"type" => "string"}


### PR DESCRIPTION
Lots of core tests were explicitly using draft-03, which works slightly
differently to the latest (draft-04 as I write this). I've rewritten
them to not specify the schema version at all, so they default to using
the latest.

To me this feels safer, as (unless explicitly specified) we're always
testing against the default draft.

The main change here is the way that the "required" property has
changed (moving from being defined on the definition of each "property"
to being defined alongside the "properties" object).