### PR TITLE
Made sure clear_cache also clears the cache of parsed uris

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+- Made the `:clear_cache` option for `validate` also clear the URI parse cache
+
 ## [2.7.0] - 2016-09-29
 
 ### Fixed

--- a/lib/json-schema/util/uri.rb
+++ b/lib/json-schema/util/uri.rb
@@ -63,6 +63,11 @@ module JSON
 
         Addressable::URI.unescape(parsed_uri.path)
       end
+
+      def self.clear_cache
+        @parse_cache = {}
+        @normalize_cache = {}
+      end
     end
   end
 end

--- a/lib/json-schema/validator.rb
+++ b/lib/json-schema/validator.rb
@@ -299,6 +299,7 @@ module JSON
 
       def clear_cache
         @@schemas = {}
+        JSON::Util::URI.clear_cache
       end
 
       def schemas

--- a/test/uri_parsing_test.rb
+++ b/test/uri_parsing_test.rb
@@ -2,6 +2,16 @@
 require File.expand_path('../support/test_helper', __FILE__)
 
 class UriParsingTest < Minitest::Test
+  def populate_cache_with(str, &blk)
+    cached_uri = Addressable::URI.parse(str)
+    Addressable::URI.stub(:parse, cached_uri, &blk)
+    cached_uri
+  end
+
+  def teardown
+    JSON::Util::URI.clear_cache
+  end
+
   def test_asian_characters
     schema = {
       "$schema"=> "http://json-schema.org/draft-04/schema#",
@@ -63,5 +73,108 @@ class UriParsingTest < Minitest::Test
     data = {"first" => "john"}
     schema = "test/schemas/ref john with spaces schema.json"
     assert_valid schema, data
+  end
+
+  def test_normalized_uri
+    str = "https://www.google.com/search"
+    uri = Addressable::URI.new(scheme: 'https',
+                               host: 'www.google.com',
+                               path: 'search')
+    assert_equal uri, JSON::Util::URI.normalized_uri(str, '/home')
+  end
+
+  def test_normalized_uri_with_empty_fragment
+    str = "https://www.google.com/search#"
+    uri = Addressable::URI.new(scheme: 'https',
+                               host: 'www.google.com',
+                               path: 'search',
+                               fragment: nil)
+    assert_equal uri, JSON::Util::URI.normalized_uri(str, '/home')
+  end
+
+  def test_normalized_uri_with_fragment
+    str = "https://www.google.com/search#foo"
+    uri = Addressable::URI.new(scheme: 'https',
+                               host: 'www.google.com',
+                               path: 'search',
+                               fragment: 'foo')
+    assert_equal uri, JSON::Util::URI.normalized_uri(str, '/home')
+  end
+
+  def test_normalized_uri_for_absolute_path
+    str = "/foo/bar.json"
+    uri = Addressable::URI.new(scheme: 'file',
+                               path: '///foo/bar.json')
+    assert_equal uri, JSON::Util::URI.normalized_uri(str, '/home')
+  end
+
+  def test_normalized_uri_for_relartive_path
+    str = "foo/bar.json"
+    uri = Addressable::URI.new(scheme: 'file',
+                               path: '///home/foo/bar.json')
+    assert_equal uri, JSON::Util::URI.normalized_uri(str, '/home')
+  end
+
+  def test_uri_parse
+    str = "https://www.google.com/search"
+    uri = Addressable::URI.new(scheme: 'https',
+                               host: 'www.google.com',
+                               path: 'search')
+    assert_equal uri, JSON::Util::URI.parse(str)
+  end
+
+  def test_invalid_uri_parse
+    uri = ":::::::"
+    assert_raises(JSON::Schema::UriError) do
+      JSON::Util::URI.parse(uri)
+    end
+  end
+
+  def test_normalization_cache
+    cached_uri = populate_cache_with('www.google.com') do
+      JSON::Util::URI.normalized_uri('foo')
+    end
+
+    assert_equal(cached_uri, JSON::Util::URI.normalized_uri('foo'))
+
+    JSON::Util::URI.clear_cache
+
+    refute_equal(cached_uri, JSON::Util::URI.normalized_uri('foo'))
+  end
+
+  def test_parse_cache
+    cached_uri = populate_cache_with('www.google.com') do
+      JSON::Util::URI.parse('foo')
+    end
+
+    assert_equal(cached_uri, JSON::Util::URI.parse('foo'))
+
+    JSON::Util::URI.clear_cache
+
+    refute_equal(cached_uri, JSON::Util::URI.parse('foo'))
+  end
+
+  def test_validator_clear_cache_for_normalized_uri
+    cached_uri = populate_cache_with('www.google.com') do
+      JSON::Util::URI.normalized_uri('foo')
+    end
+
+    assert_equal(cached_uri, JSON::Util::URI.normalized_uri('foo'))
+
+    validation_errors({"type" => "string"}, "foo", :clear_cache => true)
+
+    refute_equal(cached_uri, JSON::Util::URI.normalized_uri('foo'))
+  end
+
+  def test_validator_clear_cache_for_parse
+    cached_uri = populate_cache_with('www.google.com') do
+      JSON::Util::URI.parse('foo')
+    end
+
+    assert_equal(cached_uri, JSON::Util::URI.parse('foo'))
+
+    validation_errors({"type" => "string"}, "foo", :clear_cache => true)
+
+    refute_equal(cached_uri, JSON::Util::URI.parse('foo'))
   end
 end


### PR DESCRIPTION
There are two main caches in json-schema. One is for schemas, one is for
parsed uris. Previously, setting `:clear_cache` as a validation option
would clear the schema cache but not the uri cache. This has been
reported to cause a memory leak (see issue #329) as over time the uri
cache gets bigger and bigger and is never cleared.

This change makes sure that whenever the schema cache is cleared, the
uri cache is also cleared.

Incidentally this change is not thread safe, and multithreaded
applications that clear the cache may see  issues. But until we can
refactor to either disable caching or get rid of class variables,
I don't believe there's much we can (realistically) do about that. This
is still an improvement on what's gone before.