### PR TITLE
Load local copy of draft schemas

### DIFF
--- a/lib/json-schema/validator.rb
+++ b/lib/json-schema/validator.rb
@@ -134,6 +134,9 @@ module JSON
       schema_uri = JSON::Util::URI.absolutize_ref(ref, parent_schema.uri)
       return true if self.class.schema_loaded?(schema_uri)
 
+      validator = self.class.validator_for_uri(schema_uri, false)
+      schema_uri = JSON::Util::URI.file_uri(validator.metaschema) if validator
+
       schema = @options[:schema_reader].read(schema_uri)
       self.class.add_schema(schema)
       build_schemas(schema)

--- a/resources/draft-03.json
+++ b/resources/draft-03.json
@@ -1,174 +1,174 @@
 {
-	"$schema" : "http://json-schema.org/draft-03/schema#",
-	"id" : "http://json-schema.org/draft-03/schema#",
-	"type" : "object",
-	
-	"properties" : {
-		"type" : {
-			"type" : ["string", "array"],
-			"items" : {
-				"type" : ["string", {"$ref" : "#"}]
-			},
-			"uniqueItems" : true,
-			"default" : "any"
-		},
-		
-		"properties" : {
-			"type" : "object",
-			"additionalProperties" : {"$ref" : "#"},
-			"default" : {}
-		},
-		
-		"patternProperties" : {
-			"type" : "object",
-			"additionalProperties" : {"$ref" : "#"},
-			"default" : {}
-		},
-		
-		"additionalProperties" : {
-			"type" : [{"$ref" : "#"}, "boolean"],
-			"default" : {}
-		},
-		
-		"items" : {
-			"type" : [{"$ref" : "#"}, "array"],
-			"items" : {"$ref" : "#"},
-			"default" : {}
-		},
-		
-		"additionalItems" : {
-			"type" : [{"$ref" : "#"}, "boolean"],
-			"default" : {}
-		},
-		
-		"required" : {
-			"type" : "boolean",
-			"default" : false
-		},
-		
-		"dependencies" : {
-			"type" : "object",
-			"additionalProperties" : {
-				"type" : ["string", "array", {"$ref" : "#"}],
-				"items" : {
-					"type" : "string"
-				}
-			},
-			"default" : {}
-		},
-		
-		"minimum" : {
-			"type" : "number"
-		},
-		
-		"maximum" : {
-			"type" : "number"
-		},
-		
-		"exclusiveMinimum" : {
-			"type" : "boolean",
-			"default" : false
-		},
-		
-		"exclusiveMaximum" : {
-			"type" : "boolean",
-			"default" : false
-		},
-		
-		"minItems" : {
-			"type" : "integer",
-			"minimum" : 0,
-			"default" : 0
-		},
-		
-		"maxItems" : {
-			"type" : "integer",
-			"minimum" : 0
-		},
-		
-		"uniqueItems" : {
-			"type" : "boolean",
-			"default" : false
-		},
-		
-		"pattern" : {
-			"type" : "string",
-			"format" : "regex"
-		},
-		
-		"minLength" : {
-			"type" : "integer",
-			"minimum" : 0,
-			"default" : 0
-		},
-		
-		"maxLength" : {
-			"type" : "integer"
-		},
-		
-		"enum" : {
-			"type" : "array",
-			"minItems" : 1,
-			"uniqueItems" : true
-		},
-		
-		"default" : {
-			"type" : "any"
-		},
-		
-		"title" : {
-			"type" : "string"
-		},
-		
-		"description" : {
-			"type" : "string"
-		},
-		
-		"format" : {
-			"type" : "string"
-		},
-		
-		"divisibleBy" : {
-			"type" : "number",
-			"minimum" : 0,
-			"exclusiveMinimum" : true,
-			"default" : 1
-		},
-		
-		"disallow" : {
-			"type" : ["string", "array"],
-			"items" : {
-				"type" : ["string", {"$ref" : "#"}]
-			},
-			"uniqueItems" : true
-		},
-		
-		"extends" : {
-			"type" : [{"$ref" : "#"}, "array"],
-			"items" : {"$ref" : "#"},
-			"default" : {}
-		},
-		
-		"id" : {
-			"type" : "string",
-			"format" : "uri"
-		},
-		
-		"$ref" : {
-			"type" : "string",
-			"format" : "uri"
-		},
-		
-		"$schema" : {
-			"type" : "string",
-			"format" : "uri"
-		}
-	},
-	
-	"dependencies" : {
-		"exclusiveMinimum" : "minimum",
-		"exclusiveMaximum" : "maximum"
-	},
-	
-	"default" : {}
+    "$schema": "http://json-schema.org/draft-03/schema#",
+    "id": "http://json-schema.org/draft-03/schema#",
+    "type": "object",
+    
+    "properties": {
+        "type": {
+            "type": [ "string", "array" ],
+            "items": {
+                "type": [ "string", { "$ref": "#" } ]
+            },
+            "uniqueItems": true,
+            "default": "any"
+        },
+        
+        "properties": {
+            "type": "object",
+            "additionalProperties": { "$ref": "#" },
+            "default": {}
+        },
+        
+        "patternProperties": {
+            "type": "object",
+            "additionalProperties": { "$ref": "#" },
+            "default": {}
+        },
+        
+        "additionalProperties": {
+            "type": [ { "$ref": "#" }, "boolean" ],
+            "default": {}
+        },
+        
+        "items": {
+            "type": [ { "$ref": "#" }, "array" ],
+            "items": { "$ref": "#" },
+            "default": {}
+        },
+        
+        "additionalItems": {
+            "type": [ { "$ref": "#" }, "boolean" ],
+            "default": {}
+        },
+        
+        "required": {
+            "type": "boolean",
+            "default": false
+        },
+        
+        "dependencies": {
+            "type": "object",
+            "additionalProperties": {
+                "type": [ "string", "array", { "$ref": "#" } ],
+                "items": {
+                    "type": "string"
+                }
+            },
+            "default": {}
+        },
+        
+        "minimum": {
+            "type": "number"
+        },
+        
+        "maximum": {
+            "type": "number"
+        },
+        
+        "exclusiveMinimum": {
+            "type": "boolean",
+            "default": false
+        },
+        
+        "exclusiveMaximum": {
+            "type": "boolean",
+            "default": false
+        },
+        
+        "minItems": {
+            "type": "integer",
+            "minimum": 0,
+            "default": 0
+        },
+        
+        "maxItems": {
+            "type": "integer",
+            "minimum": 0
+        },
+        
+        "uniqueItems": {
+            "type": "boolean",
+            "default": false
+        },
+        
+        "pattern": {
+            "type": "string",
+            "format": "regex"
+        },
+        
+        "minLength": {
+            "type": "integer",
+            "minimum": 0,
+            "default": 0
+        },
+        
+        "maxLength": {
+            "type": "integer"
+        },
+        
+        "enum": {
+            "type": "array",
+            "minItems": 1,
+            "uniqueItems": true
+        },
+        
+        "default": {
+            "type": "any"
+        },
+        
+        "title": {
+            "type": "string"
+        },
+        
+        "description": {
+            "type": "string"
+        },
+        
+        "format": {
+            "type": "string"
+        },
+        
+        "divisibleBy": {
+            "type": "number",
+            "minimum": 0,
+            "exclusiveMinimum": true,
+            "default": 1
+        },
+        
+        "disallow": {
+            "type": [ "string", "array" ],
+            "items": {
+                "type": [ "string", { "$ref": "#" } ]
+            },
+            "uniqueItems": true
+        },
+        
+        "extends": {
+            "type": [ { "$ref": "#" }, "array" ],
+            "items": { "$ref": "#" },
+            "default": {}
+        },
+        
+        "id": {
+            "type": "string",
+            "format": "uri"
+        },
+        
+        "$ref": {
+            "type": "string",
+            "format": "uri"
+        },
+        
+        "$schema": {
+            "type": "string",
+            "format": "uri"
+        }
+    },
+    
+    "dependencies": {
+        "exclusiveMinimum": "minimum",
+        "exclusiveMaximum": "maximum"
+    },
+    
+    "default": {}
 }

--- a/test/load_ref_schema_test.rb
+++ b/test/load_ref_schema_test.rb
@@ -35,4 +35,11 @@ class LoadRefSchemaTest < Minitest::Test
 
     assert JSON::Validator.schema_loaded?(schema_url)
   end
+
+  def test_metaschema
+    schema = { "$ref" => "http://json-schema.org/draft-04/schema#" }
+    data = {}
+
+    assert_valid schema, data
+  end
 end


### PR DESCRIPTION
If you refer to a draft schema in a $ref (as the common test suite does)
json-schema will load it from json-schema.org even though the gem
contains a local copy.

This change patches JSON::Validator#load_ref_schema to check whether a
$ref refers to a draft schema before trying to load from the web, and if
so parsing and serving up the local copy.

I've also replaced the local copy of draft3 with the exact version found
online (only whitespace was different).