### PR TITLE
Updated ruby versions for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ rvm:
   - "2.0"
   - "2.1"
   - "2.2"
-  - "2.3.1"
-  - "jruby"
+  - "2.3.3"
+  - "jruby-9.1.7.0"
 
 sudo: false
 
@@ -15,10 +15,12 @@ install:
 matrix:
   include:
     - rvm: "1.9"
-      gemfile: "gemfiles/Gemfile.json_v1.x"
-    - rvm: "2.3.1"
+      gemfile: "gemfiles/Gemfile.ruby_19.x"
+    - rvm: "jruby-1.7"
+      gemfile: "gemfiles/Gemfile.ruby_19.x"
+    - rvm: "2.3.3"
       gemfile: "gemfiles/Gemfile.multi_json.x"
-    - rvm: "2.3.1"
+    - rvm: "2.3.3"
       gemfile: "gemfiles/Gemfile.yajl-ruby.x"
-    - rvm: "2.3.1"
+    - rvm: "2.3.3"
       gemfile: "gemfiles/Gemfile.uuidtools.x"

--- a/gemfiles/Gemfile.ruby_19.x
+++ b/gemfiles/Gemfile.ruby_19.x
@@ -3,3 +3,4 @@ source "https://rubygems.org"
 gemspec :path => "../"
 
 gem "json", "~> 1.0"
+gem "addressable", "< 2.5"

--- a/test/uri_util_test.rb
+++ b/test/uri_util_test.rb
@@ -40,14 +40,24 @@ class UriUtilTest < Minitest::Test
   def test_normalized_uri_for_absolute_path
     str = "/foo/bar.json"
     uri = Addressable::URI.new(scheme: 'file',
-                               path: '///foo/bar.json')
+                               host: '',
+                               path: '/foo/bar.json')
     assert_equal uri, JSON::Util::URI.normalized_uri(str, '/home')
   end
 
-  def test_normalized_uri_for_relartive_path
+  def test_normalized_uri_for_relative_path
     str = "foo/bar.json"
     uri = Addressable::URI.new(scheme: 'file',
-                               path: '///home/foo/bar.json')
+                               host: '',
+                               path: '/home/foo/bar.json')
+    assert_equal uri, JSON::Util::URI.normalized_uri(str, '/home')
+  end
+
+  def test_normalized_uri_for_file_path_with_host
+    str = "file://localhost/foo/bar.json"
+    uri = Addressable::URI.new(scheme: 'file',
+                               host: 'localhost',
+                               path: '/foo/bar.json')
     assert_equal uri, JSON::Util::URI.normalized_uri(str, '/home')
   end
 


### PR DESCRIPTION
We only seem to be testing against jruby 1.7, not jruby 9k.

Also, we're on an older ruby 2.3 version.

Ruby 2.4 support requires code changes (see #368 )