### PR TITLE
Fix for string invalid scheme error when string contains colon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 
 ### Fixed
-
 - Corrected the draft6 schema id to `http://json-schema.org/draft/schema#`
+- Rescue URI error when initializing a data string that contains a colon 
 
 ## [2.8.0] - 2017-02-07
 

--- a/lib/json-schema/validator.rb
+++ b/lib/json-schema/validator.rb
@@ -578,7 +578,7 @@ module JSON
             begin
               json_uri = Util::URI.normalized_uri(data)
               data = self.class.parse(custom_open(json_uri))
-            rescue JSON::Schema::JsonLoadError
+            rescue JSON::Schema::JsonLoadError, JSON::Schema::UriError
               # Silently discard the error - use the data as-is
             end
           end

--- a/test/initialize_data_test.rb
+++ b/test/initialize_data_test.rb
@@ -96,6 +96,21 @@ class InitializeDataTest < Minitest::Test
     assert_raises(JSON::Schema::JsonLoadError) { JSON::Validator.validate(schema, data, :uri => true) }
   end
 
+  def test_parse_invalid_scheme_string
+    schema = {'type' => 'string'}
+    data = 'pick one: [1, 2, 3]'
+
+    assert(JSON::Validator.validate(schema, data))
+
+    assert(JSON::Validator.validate(schema, data, :parse_data => false))
+
+    assert_raises(JSON::Schema::JsonParseError) do
+      JSON::Validator.validate(schema, data, :json => true)
+    end
+
+    assert_raises(JSON::Schema::UriError) { JSON::Validator.validate(schema, data, :uri => true) }
+  end
+
   def test_parse_integer
     schema = {'type' => 'integer'}
     data = 42

--- a/test/initialize_data_test.rb
+++ b/test/initialize_data_test.rb
@@ -56,6 +56,21 @@ class InitializeDataTest < Minitest::Test
     assert_raises(JSON::Schema::JsonLoadError) { JSON::Validator.validate(schema, data, :uri => true) }
   end
 
+  def test_parse_plain_text_string
+    schema = {'type' => 'string'}
+    data = 'kapow'
+
+    assert(JSON::Validator.validate(schema, data))
+
+    assert(JSON::Validator.validate(schema, data, :parse_data => false))
+
+    assert_raises(JSON::Schema::JsonParseError) do
+      JSON::Validator.validate(schema, data, :json => true)
+    end
+
+    assert_raises(JSON::Schema::JsonLoadError) { JSON::Validator.validate(schema, data, :uri => true) }
+  end
+
   def test_parse_valid_uri_string
     schema = {'type' => 'string'}
     data = 'http://foo.bar/'


### PR DESCRIPTION
I found a very odd edge case that will cause the `JSON::Schema::UriError` to be raised if a string JSON contains a colon.
ex. `look at this: oh no!`

To fix this I have added the exception to the `initialize_data` final rescue, as it seemed to make sense that it is caught and silently discarded in this case.

If the URI option is passed to the validator it will still raise the correct error.

If an invalid URI is passed to the validator, without the URI option, then it would also be silently discarded, I'm not sure if this is the best approach to this, my guess was that it would be user error, but opinions/references would be greatly appreciated as this is not really my area.