### PR TITLE
Re-enabled test warnings

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -21,8 +21,7 @@ end
 
 Rake::TestTask.new do |t|
   t.libs << "."
-  # disabled warnings because addressable 2.4 has lots of them
-  t.warning = false
+  t.warning = true
   t.verbose = true
   t.test_files = FileList.new('test/*_test.rb')
 end


### PR DESCRIPTION
We previously disabled warnings in tests due to an issue with
addressable 2.4 that caused huge numbers of warning messages in every
test run. That issue has been fixed now, so we can reenable
warnings (which should help detect potential issues in new code)