### PR TITLE
Added a rake task to automatically download the latest metaschemas

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -19,6 +19,43 @@ task :update_common_tests do
   end
 end
 
+desc "Update meta-schemas to the latest version"
+task :update_meta_schemas do
+  puts "Updating meta-schemas..."
+
+  id_mappings = {
+    'http://json-schema.org/draft/schema#' => 'https://raw.githubusercontent.com/json-schema-org/json-schema-spec/master/schema.json'
+  }
+
+  require 'open-uri'
+  require 'thwait'
+
+  download_threads = Dir['resources/*.json'].map do |path|
+    schema_id = File.read(path)[/"\$?id"\s*:\s*"(.*?)"/, 1]
+    schema_uri = id_mappings[schema_id] || schema_id
+
+    Thread.new(schema_uri) do |uri|
+      Thread.current[:uri] = uri
+
+      begin
+        metaschema = URI(uri).read
+
+        File.write(path, metaschema)
+      rescue StandardError
+        false
+      end
+    end
+  end
+
+  ThreadsWait.all_waits(*download_threads) do |t|
+    if t.value
+      puts t[:uri]
+    else
+      STDERR.puts "Failed to update meta-schema #{t[:uri]}"
+    end
+  end
+end
+
 Rake::TestTask.new do |t|
   t.libs << "."
   # disabled warnings because addressable 2.4 has lots of them
@@ -26,5 +63,7 @@ Rake::TestTask.new do |t|
   t.verbose = true
   t.test_files = FileList.new('test/*_test.rb')
 end
+
+task update: [:update_common_tests, :update_meta_schemas]
 
 task :default => :test


### PR DESCRIPTION
The metaschemas change occasionally. Draft6 is changing all the time
as new features are added. So we can keep on top of this, I've added a
new rake task which will download all of the latest metaschemas and
save them over the existing ones (in the resources directory)