### PR TITLE
Corrected the draf6 schema id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Corrected the draft6 schema id to `http://json-schema.org/draft/schema#`
+
 ## [2.8.0] - 2017-02-07
 
 ### Added

--- a/lib/json-schema/validators/draft6.rb
+++ b/lib/json-schema/validators/draft6.rb
@@ -43,8 +43,8 @@ module JSON
           'uri' => UriFormat
         }
         @formats = @default_formats.clone
-        @uri = JSON::Util::URI.parse("http://json-schema.org/draft-06/schema#")
-        @names = ["draft6", "http://json-schema.org/draft-06/schema#"]
+        @uri = JSON::Util::URI.parse("http://json-schema.org/draft/schema#")
+        @names = ["draft6", "http://json-schema.org/draft/schema#"]
         @metaschema_name = "draft-06.json"
       end
 

--- a/resources/draft-06.json
+++ b/resources/draft-06.json
@@ -1,7 +1,7 @@
 {
-    "id": "http://json-schema.org/draft-06/schema#",
-    "$schema": "http://json-schema.org/draft-06/schema#",
-    "description": "Core schema meta-schema",
+    "$schema": "http://json-schema.org/draft/schema#",
+    "$id": "http://json-schema.org/draft/schema#",
+    "title": "Core schema meta-schema",
     "definitions": {
         "schemaArray": {
             "type": "array",
@@ -13,27 +13,42 @@
             "minimum": 0
         },
         "positiveIntegerDefault0": {
-            "allOf": [ { "$ref": "#/definitions/positiveInteger" }, { "default": 0 } ]
+            "allOf": [
+                { "$ref": "#/definitions/positiveInteger" },
+                { "default": 0 }
+            ]
         },
         "simpleTypes": {
-            "enum": [ "array", "boolean", "integer", "null", "number", "object", "string" ]
+            "enum": [
+                "array",
+                "boolean",
+                "integer",
+                "null",
+                "number",
+                "object",
+                "string"
+            ]
         },
         "stringArray": {
             "type": "array",
             "items": { "type": "string" },
-            "minItems": 1,
-            "uniqueItems": true
+            "uniqueItems": true,
+            "defaultItems": []
         }
     },
-    "type": "object",
+    "type": ["object", "boolean"],
     "properties": {
-        "id": {
+        "$id": {
             "type": "string",
-            "format": "uri"
+            "format": "uri-reference"
         },
         "$schema": {
             "type": "string",
             "format": "uri"
+        },
+        "$ref": {
+            "type": "string",
+            "format": "uri-reference"
         },
         "title": {
             "type": "string"
@@ -44,22 +59,19 @@
         "default": {},
         "multipleOf": {
             "type": "number",
-            "minimum": 0,
-            "exclusiveMinimum": true
+            "exclusiveMinimum": 0
         },
         "maximum": {
             "type": "number"
         },
         "exclusiveMaximum": {
-            "type": "boolean",
-            "default": false
+            "type": "number"
         },
         "minimum": {
             "type": "number"
         },
         "exclusiveMinimum": {
-            "type": "boolean",
-            "default": false
+            "type": "number"
         },
         "maxLength": { "$ref": "#/definitions/positiveInteger" },
         "minLength": { "$ref": "#/definitions/positiveIntegerDefault0" },
@@ -67,13 +79,7 @@
             "type": "string",
             "format": "regex"
         },
-        "additionalItems": {
-            "anyOf": [
-                { "type": "boolean" },
-                { "$ref": "#" }
-            ],
-            "default": {}
-        },
+        "additionalItems": { "$ref": "#" },
         "items": {
             "anyOf": [
                 { "$ref": "#" },
@@ -87,16 +93,11 @@
             "type": "boolean",
             "default": false
         },
+        "contains": { "$ref": "#" },
         "maxProperties": { "$ref": "#/definitions/positiveInteger" },
         "minProperties": { "$ref": "#/definitions/positiveIntegerDefault0" },
         "required": { "$ref": "#/definitions/stringArray" },
-        "additionalProperties": {
-            "anyOf": [
-                { "type": "boolean" },
-                { "$ref": "#" }
-            ],
-            "default": {}
-        },
+        "additionalProperties": { "$ref": "#" },
         "definitions": {
             "type": "object",
             "additionalProperties": { "$ref": "#" },
@@ -121,6 +122,8 @@
                 ]
             }
         },
+        "propertyNames": { "$ref": "#" },
+        "const": {},
         "enum": {
             "type": "array",
             "minItems": 1,
@@ -137,14 +140,11 @@
                 }
             ]
         },
+        "format": { "type": "string" },
         "allOf": { "$ref": "#/definitions/schemaArray" },
         "anyOf": { "$ref": "#/definitions/schemaArray" },
         "oneOf": { "$ref": "#/definitions/schemaArray" },
         "not": { "$ref": "#" }
-    },
-    "dependencies": {
-        "exclusiveMaximum": [ "maximum" ],
-        "exclusiveMinimum": [ "minimum" ]
     },
     "default": {}
 }

--- a/test/custom_format_test.rb
+++ b/test/custom_format_test.rb
@@ -6,7 +6,7 @@ class CustomFormatTest < Minitest::Test
     @all_versions = ['draft1', 'draft2', 'draft3', 'draft4', 'draft6', nil]
     @format_proc = lambda { |value| raise JSON::Schema::CustomFormatError.new("must be 42") unless value == "42" }
     @schema_6 = {
-      "$schema" => "http://json-schema.org/draft-06/schema#",
+      "$schema" => "http://json-schema.org/draft/schema#",
       "properties" => {
         "a" => {
           "type" => "string",


### PR DESCRIPTION
Draft6 is a work in progress. The maintainers for now are using the
schema id "http://json-schema.org/draft/schema#". Previously I had
assumed it would follow the naming convention of the previous
drafts (and include the version number in the name). Unfortunately I
was wrong, so now I've updated it to use the correct schema id.

I've also updated the meta schema to the latest version.