### PR TITLE
Changed draft-06 url back from /draft/schema# to /draft-06/schema#

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,6 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - All attribute classes are now stored in their own files in 'json-schema/attributes'
 
 ### Fixed
-- Corrected the draft6 schema id to `http://json-schema.org/draft/schema#`
 - Rescue URI error when initializing a data string that contains a colon
 - Fragments with an odd number of components no longer raise an `undefined method `validate'`
   error

--- a/Rakefile
+++ b/Rakefile
@@ -23,16 +23,11 @@ desc "Update meta-schemas to the latest version"
 task :update_meta_schemas do
   puts "Updating meta-schemas..."
 
-  id_mappings = {
-    'http://json-schema.org/draft/schema#' => 'https://raw.githubusercontent.com/json-schema-org/json-schema-spec/master/schema.json'
-  }
-
   require 'open-uri'
   require 'thwait'
 
   download_threads = Dir['resources/*.json'].map do |path|
-    schema_id = File.read(path)[/"\$?id"\s*:\s*"(.*?)"/, 1]
-    schema_uri = id_mappings[schema_id] || schema_id
+    schema_uri = File.read(path)[/"\$?id"\s*:\s*"(.*?)"/, 1]
 
     Thread.new(schema_uri) do |uri|
       Thread.current[:uri] = uri

--- a/lib/json-schema/validators/draft6.rb
+++ b/lib/json-schema/validators/draft6.rb
@@ -43,8 +43,8 @@ module JSON
           'uri' => UriFormat
         }
         @formats = @default_formats.clone
-        @uri = JSON::Util::URI.parse("http://json-schema.org/draft/schema#")
-        @names = ["draft6", "http://json-schema.org/draft/schema#"]
+        @uri = JSON::Util::URI.parse("http://json-schema.org/draft-06/schema#")
+        @names = ["draft6", "http://json-schema.org/draft-06/schema#"]
         @metaschema_name = "draft-06.json"
       end
 

--- a/resources/draft-06.json
+++ b/resources/draft-06.json
@@ -1,6 +1,6 @@
 {
-    "$schema": "http://json-schema.org/draft/schema#",
-    "$id": "http://json-schema.org/draft/schema#",
+    "$schema": "http://json-schema.org/draft-06/schema#",
+    "$id": "http://json-schema.org/draft-06/schema#",
     "title": "Core schema meta-schema",
     "definitions": {
         "schemaArray": {
@@ -8,13 +8,13 @@
             "minItems": 1,
             "items": { "$ref": "#" }
         },
-        "positiveInteger": {
+        "nonNegativeInteger": {
             "type": "integer",
             "minimum": 0
         },
-        "positiveIntegerDefault0": {
+        "nonNegativeIntegerDefault0": {
             "allOf": [
-                { "$ref": "#/definitions/positiveInteger" },
+                { "$ref": "#/definitions/nonNegativeInteger" },
                 { "default": 0 }
             ]
         },
@@ -33,7 +33,7 @@
             "type": "array",
             "items": { "type": "string" },
             "uniqueItems": true,
-            "defaultItems": []
+            "default": []
         }
     },
     "type": ["object", "boolean"],
@@ -73,8 +73,8 @@
         "exclusiveMinimum": {
             "type": "number"
         },
-        "maxLength": { "$ref": "#/definitions/positiveInteger" },
-        "minLength": { "$ref": "#/definitions/positiveIntegerDefault0" },
+        "maxLength": { "$ref": "#/definitions/nonNegativeInteger" },
+        "minLength": { "$ref": "#/definitions/nonNegativeIntegerDefault0" },
         "pattern": {
             "type": "string",
             "format": "regex"
@@ -87,15 +87,15 @@
             ],
             "default": {}
         },
-        "maxItems": { "$ref": "#/definitions/positiveInteger" },
-        "minItems": { "$ref": "#/definitions/positiveIntegerDefault0" },
+        "maxItems": { "$ref": "#/definitions/nonNegativeInteger" },
+        "minItems": { "$ref": "#/definitions/nonNegativeIntegerDefault0" },
         "uniqueItems": {
             "type": "boolean",
             "default": false
         },
         "contains": { "$ref": "#" },
-        "maxProperties": { "$ref": "#/definitions/positiveInteger" },
-        "minProperties": { "$ref": "#/definitions/positiveIntegerDefault0" },
+        "maxProperties": { "$ref": "#/definitions/nonNegativeInteger" },
+        "minProperties": { "$ref": "#/definitions/nonNegativeIntegerDefault0" },
         "required": { "$ref": "#/definitions/stringArray" },
         "additionalProperties": { "$ref": "#" },
         "definitions": {

--- a/test/custom_format_test.rb
+++ b/test/custom_format_test.rb
@@ -6,7 +6,7 @@ class CustomFormatTest < Minitest::Test
     @all_versions = ['draft1', 'draft2', 'draft3', 'draft4', 'draft6', nil]
     @format_proc = lambda { |value| raise JSON::Schema::CustomFormatError.new("must be 42") unless value == "42" }
     @schema_6 = {
-      "$schema" => "http://json-schema.org/draft/schema#",
+      "$schema" => "http://json-schema.org/draft-06/schema#",
       "properties" => {
         "a" => {
           "type" => "string",


### PR DESCRIPTION
Originally, when I added draft6 support there were draft06 tests in
the common test suite, but no meta schema was available, so I assumed
the url would match the format of older
drafts (ie. http://json-schema.org/draft-06/schema#)

Then when the first version of the draft6 meta schema was released,
it's official url was http://json-schema.org/draft/schema# (although
it wasn't available on json-schema.org, it was only available on
github.com).

Now the draft6 metaschema is being hosted on json-schema.org, and the
url matches what I'd originally predicted:
http://json-schema.org/draft-06/schema#, so I've changed it back
again.

Because of that, this is largely a revert for
87e7b0aecd89ce3ff2c1dcd7dd524251cff0a464, but I've also updated the
meta schema to the latest version and updated the
`update_meta_schemas` rake task to remove the redirect to github.com
to download the meta schema.