### PR TITLE
Allow override of required in strict mode

### DIFF
--- a/lib/json-schema/attributes/properties_v4.rb
+++ b/lib/json-schema/attributes/properties_v4.rb
@@ -6,7 +6,7 @@ module JSON
       # draft4 relies on its own RequiredAttribute validation at a higher level, rather than
       # as an attribute of individual properties.
       def self.required?(schema, options)
-        options[:strict] == true
+        false
       end
     end
   end

--- a/lib/json-schema/schema/validator.rb
+++ b/lib/json-schema/schema/validator.rb
@@ -20,7 +20,12 @@ module JSON
       end
 
       def validate(current_schema, data, fragments, processor, options = {})
-        current_schema.schema.each do |attr_name,attribute|
+        schema = current_schema.schema
+        if options[:strict] && schema['required'].nil? && schema['properties']
+          schema['required'] = schema['properties'].keys
+        end
+
+        schema.each do |attr_name,attribute|
           if @attributes.has_key?(attr_name.to_s)
             @attributes[attr_name.to_s].validate(current_schema, data, fragments, processor, self, options)
           end

--- a/test/support/strict_validation.rb
+++ b/test/support/strict_validation.rb
@@ -85,4 +85,26 @@ module StrictValidation
     assert(!JSON::Validator.validate(schema,data,:strict => true))
   end
 
+  def test_strict_properties_with_required_override
+    schema = {
+      "required" => ["a"],
+      "properties" => {
+        "a" => {"type" => "string"},
+        "b" => {"type" => "string"}
+      }
+    }
+
+    data = {"a" => "a"}
+    assert(JSON::Validator.validate(schema,data,:strict => true))
+
+    data = {"b" => "b"}
+    assert(!JSON::Validator.validate(schema,data,:strict => true))
+
+    data = {"a" => "a", "b" => "b"}
+    assert(JSON::Validator.validate(schema,data,:strict => true))
+
+    data = {"a" => "a", "b" => "b", "c" => "c"}
+    assert(!JSON::Validator.validate(schema,data,:strict => true))
+  end
+
 end


### PR DESCRIPTION
Current functionality: required field is ignored in strict mode in favor
of making all properties required.

Proposed functionality: required field is used to override the strict
mode.

Why: This will allow people to save time by using strict mode even if some
properties are optional.