### PR TITLE
Avoid deprecate warning about BigDecimal

### DIFF
--- a/lib/json-schema/attributes/divisibleby.rb
+++ b/lib/json-schema/attributes/divisibleby.rb
@@ -12,7 +12,7 @@ module JSON
 
         factor = current_schema.schema[keyword]
 
-        if factor == 0 || factor == 0.0 || (BigDecimal.new(data.to_s) % BigDecimal.new(factor.to_s)).to_f != 0
+        if factor == 0 || factor == 0.0 || (BigDecimal(data.to_s) % BigDecimal(factor.to_s)).to_f != 0
           message = "The property '#{build_fragment(fragments)}' was not divisible by #{factor}"
           validation_error(processor, message, fragments, current_schema, self, options[:record_errors])
         end


### PR DESCRIPTION
`BigDecimal.new` is deprecated in Ruby 2.5.
The following warning is shown.

```
warning: BigDecimal.new is deprecated; use Kernel.BigDecimal method instead.
```