### PR TITLE
Load VERSION.yml from relative path, so that developers can use "bundle config local.json-schema" 

### DIFF
--- a/json-schema.gemspec
+++ b/json-schema.gemspec
@@ -1,6 +1,6 @@
 require 'yaml'
 
-version_yaml = YAML.load(File.open('VERSION.yml').read)
+version_yaml = YAML.load(File.open(File.expand_path('../VERSION.yml', __FILE__)).read)
 version = "#{version_yaml['major']}.#{version_yaml['minor']}.#{version_yaml['patch']}"
 gem_name = "json-schema"
 


### PR DESCRIPTION
I started doing a bit of work on `json-schema`, and want to test my local changes in my Rails app. So in my `Gemfile` I make `json-schema` point to my fork on GitHub, and I use `bundle config local.json-schema /path/to/repo` to use the code at `/path/to/repo` during development. (More info: https://bundler.io/v1.2/git.html#local)

This change was required, otherwise Bundler will crash with `No such file or directory @ rb_sysopen - VERSION.yml`.