### PR TITLE
Add :property_fragment to errors hash, to show which required property was missing

### DIFF
--- a/lib/json-schema/attribute.rb
+++ b/lib/json-schema/attribute.rb
@@ -10,8 +10,8 @@ module JSON
         "#/#{fragments.join('/')}"
       end
 
-      def self.validation_error(processor, message, fragments, current_schema, failed_attribute, record_errors)
-        error = ValidationError.new(message, fragments, failed_attribute, current_schema)
+      def self.validation_error(processor, message, fragments, current_schema, failed_attribute, record_errors, property = nil)
+        error = ValidationError.new(message, fragments, failed_attribute, current_schema, property)
         if record_errors
           processor.validation_error(error)
         else

--- a/lib/json-schema/attributes/dependencies.rb
+++ b/lib/json-schema/attributes/dependencies.rb
@@ -27,7 +27,7 @@ module JSON
       def self.validate_dependency(schema, data, property, value, fragments, processor, attribute, options)
         return if data.key?(value.to_s)
         message = "The property '#{build_fragment(fragments)}' has a property '#{property}' that depends on a missing property '#{value}'"
-        validation_error(processor, message, fragments, schema, attribute, options[:record_errors])
+        validation_error(processor, message, fragments, schema, attribute, options[:record_errors], property)
       end
 
       def self.accept_value?(value)

--- a/lib/json-schema/attributes/properties.rb
+++ b/lib/json-schema/attributes/properties.rb
@@ -24,7 +24,7 @@ module JSON
 
           if required?(property_schema, options) && !data.has_key?(property)
             message = "The property '#{build_fragment(fragments)}' did not contain a required property of '#{property}'"
-            validation_error(processor, message, fragments, current_schema, self, options[:record_errors])
+            validation_error(processor, message, fragments, current_schema, self, options[:record_errors], property)
           end
 
           if data.has_key?(property)

--- a/lib/json-schema/attributes/properties_optional.rb
+++ b/lib/json-schema/attributes/properties_optional.rb
@@ -12,7 +12,7 @@ module JSON
 
           if !property_schema['optional'] && !data.key?(property)
             message = "The property '#{build_fragment(fragments)}' did not contain a required property of '#{property}'"
-            validation_error(processor, message, fragments, current_schema, self, options[:record_errors])
+            validation_error(processor, message, fragments, current_schema, self, options[:record_errors], property)
           end
 
           if data.has_key?(property)

--- a/lib/json-schema/attributes/required.rb
+++ b/lib/json-schema/attributes/required.rb
@@ -19,7 +19,7 @@ module JSON
 
           if !prop_defaults
             message = "The property '#{build_fragment(fragments)}' did not contain a required property of '#{property}'"
-            validation_error(processor, message, fragments, current_schema, self, options[:record_errors])
+            validation_error(processor, message, fragments, current_schema, self, options[:record_errors], property)
           end
         end
       end

--- a/test/full_validation_test.rb
+++ b/test/full_validation_test.rb
@@ -133,11 +133,13 @@ class FullValidationTest < Minitest::Test
 
     errors = JSON::Validator.fully_validate(schema,data,:errors_as_objects => true)
 
-    assert(errors.length == 2)
-    assert(errors[0][:failed_attribute] == "Required")
-    assert(errors[0][:fragment] == "#/")
-    assert(errors[1][:failed_attribute] == "TypeV4")
-    assert(errors[1][:fragment] == "#/c")
+    assert_equal errors.length, 2
+    assert_equal errors[0][:failed_attribute], "Required"
+    assert_equal errors[0][:fragment], "#/"
+    assert_equal errors[0][:property_fragment], "#/b"
+    assert_equal errors[1][:failed_attribute], "TypeV4"
+    assert_equal errors[1][:fragment], "#/c"
+    assert_equal errors[1][:property_fragment], "#/c"
   end
 
   def test_full_validation_with_nested_required_properties
@@ -163,8 +165,10 @@ class FullValidationTest < Minitest::Test
     errors = JSON::Validator.fully_validate(schema,data,:errors_as_objects => true)
     assert_equal 2, errors.length
     assert_equal '#/x', errors[0][:fragment]
+    assert_equal '#/x/b', errors[0][:property_fragment]
     assert_equal 'Required', errors[0][:failed_attribute]
     assert_equal '#/x/e', errors[1][:fragment]
+    assert_equal '#/x/e', errors[1][:property_fragment]
     assert_equal 'TypeV4', errors[1][:failed_attribute]
   end
 
@@ -196,8 +200,10 @@ class FullValidationTest < Minitest::Test
     errors = JSON::Validator.fully_validate(schema,data,:errors_as_objects => true)
     assert_equal 2, errors.length
     assert_equal '#/x/0', errors[0][:fragment]
+    assert_equal '#/x/0/b', errors[0][:property_fragment]
     assert_equal 'Required', errors[0][:failed_attribute]
     assert_equal '#/x/1/e', errors[1][:fragment]
+    assert_equal '#/x/1/e', errors[1][:property_fragment]
     assert_equal 'TypeV4', errors[1][:failed_attribute]
   end
 end


### PR DESCRIPTION
I understand the reasoning behind `:fragment => "#/"` for a required property that is missing from the root object. But I really need to know *which* required property is missing, and I didn't want to parse it out of the message string.

I've added a new `:property_fragment` to the validation error hash, and this is a more consistent way of detecting which field is causing the validation error. For required fields, it will show the property that is missing. And it will be the same for fields that have the wrong data type, etc (because it falls back to `:fragment` by default.)

This change should be fully backwards compatible, and it just adds a new key to the error hash.