### PR TITLE
AdditionalProperties not being applied when value could be array

### DIFF
--- a/lib/json-schema/attributes/additionalproperties.rb
+++ b/lib/json-schema/attributes/additionalproperties.rb
@@ -6,7 +6,7 @@ module JSON
     class AdditionalPropertiesAttribute < Attribute
       def self.validate(current_schema, data, fragments, processor, validator, options = {})
         schema = current_schema.schema
-        return unless data.is_a?(Hash) && (schema['type'].nil? || schema['type'] == 'object')
+        return unless data.is_a?(Hash) && (schema['type'].nil? || schema['type'] == 'object' || (schema['type'].is_a?(Array) && schema['type'].include?('object')))
 
         extra_properties = remove_valid_properties(data.keys, current_schema, validator)
 


### PR DESCRIPTION
This fix should will resolve this issue #404 

Given the following schema:

`// should raise error but doesn't
{
  "type": [ "object", "null" ],
  "properties": {
    "a_string": {
      "type": "string"
    }
  },
  "additionalProperties": false
}
 `
The sample data
`object = {
  "a_string": "this property is allowed by the schema",
  "an_extra_string": "the schema does not allow this property"
}`

Previously it does not raise any error

After the fix
Following error will throw
`JSON::Schema::ValidationError: The property '#/' contains additional properties ["an_array"] outside of the schema when none are allowed`
