### PR TITLE
Make JSON::Validator freezable

### DIFF
--- a/test/full_validation_test.rb
+++ b/test/full_validation_test.rb
@@ -1,6 +1,23 @@
 require File.expand_path('../support/test_helper', __FILE__)
 
 class FullValidationTest < Minitest::Test
+  def test_frozen_validator
+    data = { 'c' => 'a' }.freeze
+    schema = {
+      'type' => 'object',
+      'required' => ['b'],
+      'properties' => {
+        'b' => {},
+      },
+    }.freeze
+
+    assert_raises JSON::Schema::ValidationError do
+      JSON::Validator.new(schema, { record_errors: false }).freeze.validate(data)
+    end
+
+    JSON::Validator.new(schema, { record_errors: true }).freeze.validate(data)
+  end
+
   def test_full_validation
     data = { 'b' => { 'a' => 5 } }
     schema = {


### PR DESCRIPTION
To avoid accidental memory leaks or other accidental modifications when reusing a validator object, a frozen validator object should still be able to validate schemas.

The only thing preventing us from freezing the validator object was the error tracking, which was temporarily stored in `@errors` and always cleaned up at the end of the #validate method.