### PR TITLE
Fix undefined properties errors when using multi level allOf schemas

### DIFF
--- a/lib/json-schema/attributes/allof.rb
+++ b/lib/json-schema/attributes/allof.rb
@@ -4,23 +4,26 @@ module JSON
   class Schema
     class AllOfAttribute < Attribute
       def self.validate(current_schema, data, fragments, processor, validator, options = {})
-        # Create an hash to hold errors that are generated during validation
-        errors = Hash.new { |hsh, k| hsh[k] = [] }
         valid = true
         message = nil
 
-        current_schema.schema['allOf'].each_with_index do |element, schema_index|
-          schema = JSON::Schema.new(element, current_schema.uri, validator)
+        # We get the properties that were explicity defined in this schema so we can ignore undefined property errors in sub schemas
+        defined_properties = current_schema.schema['allOf'].collect do |subschema|
+          if subschema.is_a?(Hash) && subschema.key?('properties') && subschema['properties'].is_a?(Hash)
+            subschema['properties'].keys.map(&:to_s)
+          else
+            []
+          end
+        end.flatten
 
-          # We're going to add a little cruft here to try and maintain any validation errors that occur in the allOf
-          # We'll handle this by keeping an error count before and after validation, extracting those errors and pushing them onto an error array
-          pre_validation_error_count = validation_errors(processor).count
+        current_schema.schema['allOf'].each_with_index do |element, _schema_index|
+          schema = JSON::Schema.new(element, current_schema.uri, validator)
 
           begin
             # Cannot raise if noAdditionalProperties is true, we need to
             # evaluate each sub schema within the allOf, before raising.
             if options[:noAdditionalProperties] == true
-              schema.validate(data, fragments, processor, options.merge(record_errors: true))
+              schema.validate(data, fragments, processor, options.merge(record_errors: true, allOf_branch: true))
             else
               schema.validate(data, fragments, processor, options)
             end
@@ -28,37 +31,48 @@ module JSON
             valid = false
             message = e.message
           end
+        end
 
-          diff = validation_errors(processor).count - pre_validation_error_count
-
-          while diff > 0
-            diff -= 1
-            errors["allOf ##{schema_index}"].push(validation_errors(processor).pop)
+        # If we have a undefined property error from a sub schema and that property was
+        # defined here, we remove it from undefined properties and discard errors if all
+        # properties are accounted for.
+        undefined_attribute_errors = []
+        validation_errors(processor).reject! do |error|
+          if error.failed_attribute == JSON::Schema::PropertiesV4Attribute
+            error.properties -= defined_properties
+            undefined_attribute_errors << error
+            error.properties.empty?
+          else
+            false
           end
         end
 
-        # Find any properties that are missing across all subschemas.
-        common_missing_properties = {}
-        if options[:noAdditionalProperties] == true && !errors.empty?
-          all_property_errors = errors.values.flatten.map(&:properties)
-          common_missing_properties = (all_property_errors.first || []).to_set
+        # If this method has been called recursively, we don't want to process
+        # validation errors yet, as we'll need to aggregate them at the top level
+        # to find the common undefined properties.
+        return if options[:allOf_branch] == true
+
+        # Find any properties that are undefined across all subschemas.
+        common_undefined_properties = {}
+        if options[:noAdditionalProperties] == true && undefined_attribute_errors.any?
+          all_property_errors = undefined_attribute_errors.map(&:properties)
+          common_undefined_properties = (all_property_errors.first || []).to_set
 
           all_property_errors[1..].each do |curr_property_errors|
-            common_missing_properties &= curr_property_errors.to_set
+            common_undefined_properties &= curr_property_errors.to_set
           end
         end
 
         # PropertiesV4Attribute represents errors that would indicate an
         # additional property was detected. If we filter these out, we should
         # be left with errors that are not dependent on any other sub schema.
-        non_missing_property_errors = errors.values.flatten.reject do |error|
+        validation_errors(processor).reject! do |error|
           error.failed_attribute == JSON::Schema::PropertiesV4Attribute
         end
 
-        if !valid || !non_missing_property_errors.empty? || !common_missing_properties.empty?
+        if !valid || !common_undefined_properties.empty? || !validation_errors(processor).empty?
           message ||= "The property '#{build_fragment(fragments)}' of type #{type_of_data(data)} did not match all of the required schemas"
           validation_error(processor, message, fragments, current_schema, self, options[:record_errors])
-          validation_errors(processor).last.sub_errors = errors
         end
       end
     end

--- a/test/all_of_ref_nested_schema_test.rb
+++ b/test/all_of_ref_nested_schema_test.rb
@@ -1,0 +1,30 @@
+require File.expand_path('support/test_helper', __dir__)
+
+class AllOfRefNestedSchemaTest < Minitest::Test
+  def schema
+    schema_fixture_path('all_of_ref_nested_schema.json')
+  end
+
+  def test_valid_nested_schema
+    data = {
+      nested: {
+        a: 'valueA',
+        b: 'valueB',
+        c: 'valueC',
+      },
+    }
+
+    assert_valid schema, data, { noAdditionalProperties: true }
+  end
+
+  def test_invalid_nested_schema
+    data = {
+      nested: {
+        a: 'valueA',
+        c: 'valueC',
+      },
+    }
+
+    refute_valid schema, data, { noAdditionalProperties: true }
+  end
+end

--- a/test/schemas/all_of_ref_nested_schema.json
+++ b/test/schemas/all_of_ref_nested_schema.json
@@ -1,0 +1,39 @@
+{
+  "definitions": {
+    "alpha": {
+      "type": "object",
+      "properties": {
+        "a": { "type": "string" }
+      },
+      "required": ["a"]
+    },
+    "bravo": {
+      "allOf": [
+        { "$ref": "#/definitions/alpha" },
+        {
+          "type": "object",
+          "properties": {
+            "b": { "type": "string" }
+          },
+          "required": ["b"]
+        }
+      ]
+    },
+    "charlie": {
+      "allOf": [
+        { "$ref": "#/definitions/bravo" },
+        {
+          "type": "object",
+          "properties": {
+            "c": { "type": "string" }
+          },
+          "required": ["c"]
+        }
+      ]
+    }
+  },
+  "type": "object",
+  "properties": {
+    "nested": { "$ref": "#/definitions/charlie" }
+  }
+}


### PR DESCRIPTION
When we have a schema with nested allOf, the validation always fails when noAdditionalProperties is true.  This changes the allOf validation to discard errors for properties that were defined in the parent schema.

However, this breaks the nested error messages which I'm not sure I can re-add without having to modify the validator itself which is a bigger change than I'm able to make right now.

I'm hoping someone has a better idea on how to restore the nested error messages.