### PR TITLE
Remove multi_json support

### DIFF
--- a/README.md
+++ b/README.md
@@ -474,10 +474,6 @@ validation:
 JSON::Validator.json_backend = :json
 ```
 
-Optionally, the JSON Schema library supports using the MultiJSON library for
-selecting JSON backends. If the MultiJSON library is installed, it will be
-autoloaded.
-
 Notes
 -----
 

--- a/lib/json-schema.rb
+++ b/lib/json-schema.rb
@@ -1,13 +1,5 @@
 require 'rubygems'
 
-if Gem::Specification.find_all_by_name('multi_json').any?
-  require 'multi_json'
-
-  # Force MultiJson to load an engine before we define the JSON constant here; otherwise,
-  # it looks for things that are under the JSON namespace that aren't there (since we have defined it here)
-  MultiJson.respond_to?(:adapter) ? MultiJson.adapter : MultiJson.engine
-end
-
 require 'json-schema/util/array_set'
 require 'json-schema/util/uri'
 require 'json-schema/schema'


### PR DESCRIPTION
Adding multi_json to a project for an unrelated reason would silently cause json-schema to use it instead of the json gem, introducing subtle behavioral differences.

With modern Ruby and the json gem, multi_json is no longer needed.

See https://github.com/voxpupuli/json-schema/issues/565